### PR TITLE
impl Clone for OnceCell<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- impl `Clone` for `OnceCell<T>` if `T: Clone>
 
 ## 1.0.5
- - No changelog until this point :(
+- No changelog until this point :(

--- a/src/imp_pl.rs
+++ b/src/imp_pl.rs
@@ -38,6 +38,20 @@ impl<T> Default for OnceCell<T> {
     }
 }
 
+impl<T: Clone> Clone for OnceCell<T> {
+    fn clone(&self) -> OnceCell<T> {
+        let value = self.get();
+        let res = OnceCell::new();
+        if let Some(value) = value {
+            match res.set(value.clone()) {
+                Ok(()) => (),
+                Err(_) => unreachable!(),
+            };
+        }
+        res
+    }
+}
+
 impl<T> OnceCell<T> {
     /// An empty cell, for initialization in a `const` context.
     pub const INIT: OnceCell<T> = OnceCell {

--- a/src/imp_std.rs
+++ b/src/imp_std.rs
@@ -42,6 +42,20 @@ impl<T> Default for OnceCell<T> {
     }
 }
 
+impl<T: Clone> Clone for OnceCell<T> {
+    fn clone(&self) -> OnceCell<T> {
+        let value = self.get();
+        let res = OnceCell::new();
+        if let Some(value) = value {
+            match res.set(value.clone()) {
+                Ok(()) => (),
+                Err(_) => unreachable!(),
+            };
+        }
+        res
+    }
+}
+
 impl<T> OnceCell<T> {
     /// An empty cell, for initialization in a `const` context.
     pub const INIT: OnceCell<T> = OnceCell {


### PR DESCRIPTION
Closes https://github.com/matklad/once_cell/issues/4

@starkat99 one thing I am worried about that there's no *strong* semantics here. What happens if one thread is calling `get_or_init`, and the over thread is calling `.clone` is indeterminate: you might get either an empty or a full cell. I think that's the reason why synch primitives like `Once` or `Mutex` don't implement `Clone` in general? Will this semantics work for you?