### PR TITLE
Add PartialEq, From<T> derives + Fix rustc 1.24.1 builds

### DIFF
--- a/src/imp_pl.rs
+++ b/src/imp_pl.rs
@@ -1,6 +1,7 @@
 extern crate parking_lot;
 
 use std::cell::UnsafeCell;
+use std::hash::{Hash, Hasher};
 use self::parking_lot::{Once, ONCE_INIT, OnceState};
 
 /// A thread-safe cell which can be written to only once.
@@ -35,6 +36,26 @@ pub struct OnceCell<T> {
 impl<T> Default for OnceCell<T> {
     fn default() -> OnceCell<T> {
         OnceCell::new()
+    }
+}
+
+impl<T> From<T> for OnceCell<T> {
+    fn from(value: T) -> Self {
+        let cell = Self::new();
+        cell.get_or_init(|| value);
+        cell
+    }
+}
+
+impl<T: PartialEq> PartialEq for OnceCell<T> {
+    fn eq(&self, other: &OnceCell<T>) -> bool {
+        self.get() == other.get()
+    }
+}
+
+impl<T: Hash> Hash for OnceCell<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.get().hash(state);
     }
 }
 

--- a/src/imp_pl.rs
+++ b/src/imp_pl.rs
@@ -1,7 +1,6 @@
 extern crate parking_lot;
 
 use std::cell::UnsafeCell;
-use std::hash::{Hash, Hasher};
 use self::parking_lot::{Once, ONCE_INIT, OnceState};
 
 /// A thread-safe cell which can be written to only once.
@@ -50,12 +49,6 @@ impl<T> From<T> for OnceCell<T> {
 impl<T: PartialEq> PartialEq for OnceCell<T> {
     fn eq(&self, other: &OnceCell<T>) -> bool {
         self.get() == other.get()
-    }
-}
-
-impl<T: Hash> Hash for OnceCell<T> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.get().hash(state);
     }
 }
 

--- a/src/imp_std.rs
+++ b/src/imp_std.rs
@@ -38,6 +38,20 @@ impl<T> Default for OnceCell<T> {
     }
 }
 
+impl<T> From<T> for OnceCell<T> {
+    fn from(value: T) -> Self {
+        let cell = Self::new();
+        cell.get_or_init(|| value);
+        cell
+    }
+}
+
+impl<T: PartialEq> PartialEq for OnceCell<T> {
+    fn eq(&self, other: &OnceCell<T>) -> bool {
+        self.get() == other.get()
+    }
+}
+
 impl<T> OnceCell<T> {
     /// An empty cell, for initialization in a `const` context.
     pub const INIT: OnceCell<T> = OnceCell {

--- a/src/imp_std.rs
+++ b/src/imp_std.rs
@@ -1,10 +1,6 @@
-use std::{
-    cell::UnsafeCell,
-    sync::{
-        Once, ONCE_INIT,
-        atomic::{AtomicBool, Ordering},
-    },
-};
+use std::cell::UnsafeCell;
+use std::sync::{Once, ONCE_INIT};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// A thread-safe cell which can be written to only once.
 ///
@@ -37,8 +33,8 @@ pub struct OnceCell<T> {
 }
 
 impl<T> Default for OnceCell<T> {
-    fn default() -> OnceCell<T> {
-        OnceCell::new()
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,6 @@ mod imp;
 pub mod unsync {
     use std::ops::Deref;
     use std::cell::UnsafeCell;
-    use std::hash::{Hash, Hasher};
 
     /// A cell which can be written to only once. Not thread safe.
     ///
@@ -225,12 +224,6 @@ pub mod unsync {
     impl<T: PartialEq> PartialEq for OnceCell<T> {
         fn eq(&self, other: &Self) -> bool {
             self.get() == other.get()
-        }
-    }
-
-    impl<T: Hash> Hash for OnceCell<T> {
-        fn hash<H: Hasher>(&self, state: &mut H) {
-            self.get().hash(state);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,10 +175,9 @@ mod imp;
 
 #[macro_use]
 pub mod unsync {
-    use std::{
-        ops::Deref,
-        cell::UnsafeCell,
-    };
+    use std::ops::Deref;
+    use std::cell::UnsafeCell;
+    use std::hash::{Hash, Hasher};
 
     /// A cell which can be written to only once. Not thread safe.
     ///
@@ -205,8 +204,8 @@ pub mod unsync {
     }
 
     impl<T> Default for OnceCell<T> {
-        fn default() -> OnceCell<T> {
-            OnceCell::new()
+        fn default() -> Self {
+            Self::new()
         }
     }
 
@@ -220,6 +219,24 @@ pub mod unsync {
                 }
             }
             res
+        }
+    }
+
+    impl<T: PartialEq> PartialEq for OnceCell<T> {
+        fn eq(&self, other: &Self) -> bool {
+            self.get() == other.get()
+        }
+    }
+
+    impl<T: Hash> Hash for OnceCell<T> {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.get().hash(state);
+        }
+    }
+
+    impl<T> From<T> for OnceCell<T> {
+        fn from(value: T) -> Self {
+            OnceCell { inner: UnsafeCell::new(Some(value)) }
         }
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -237,3 +237,24 @@ fn unsync_clone() {
     let c = s.clone();
     assert_eq!(c.get().map(String::as_str), Some("hello"));
 }
+
+#[test]
+fn from_impl() {
+    assert_eq!(sync::OnceCell::from("value").get(), Some(&"value"));
+    assert_eq!(unsync::OnceCell::from("value").get(), Some(&"value"));
+    assert_ne!(sync::OnceCell::from("foo").get(), Some(&"bar"));
+    assert_ne!(unsync::OnceCell::from("foo").get(), Some(&"bar"));
+}
+
+#[test]
+fn partialeq_impl() {
+    assert!(sync::OnceCell::from("value") == sync::OnceCell::from("value"));
+    assert!(sync::OnceCell::from("foo") != sync::OnceCell::from("bar"));
+    assert!(unsync::OnceCell::from("value") == unsync::OnceCell::from("value"));
+    assert!(unsync::OnceCell::from("foo") != unsync::OnceCell::from("bar"));
+
+    assert!(sync::OnceCell::<String>::new() == sync::OnceCell::new());
+    assert!(sync::OnceCell::<String>::new() != sync::OnceCell::from("value".to_owned()));
+    assert!(unsync::OnceCell::<String>::new() == unsync::OnceCell::new());
+    assert!(unsync::OnceCell::<String>::new() != unsync::OnceCell::from("value".to_owned()));
+}


### PR DESCRIPTION
I'd like to use this within System76 / Pop!_OS projects, but that requires an extra derive (PartialEq), and using `use` import syntax that's compatible with rustc 1.24.1. While I was there, added some additional missing derives (Hash, From<T>).