### PR TITLE
Fix unsync unsound aliasing of Option<T>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,10 +279,11 @@ pub mod unsync {
         /// assert!(cell.get().is_some());
         /// ```
         pub fn set(&self, value: T) -> Result<(), T> {
-            let slot = unsafe { &mut *self.inner.get() };
+            let slot = unsafe { &*self.inner.get() };
             if slot.is_some() {
                 return Err(value);
             }
+            let slot = unsafe { &mut*self.inner.get() };
             // This is the only place where we set the slot, no races
             // due to reentrancy/concurrency are possible, and we've
             // checked that slot is currently `None`, so this write


### PR DESCRIPTION
As per https://github.com/matklad/once_cell/issues/1, I have looked at `unsync::OnceCell` code, and found that `::once_cell::unsync::OnceCell::set` is unsound when combined with `::once_cell::unsync::OnceCell::get`:

  - for a brief moment, before `Err`-oring, we have a unique reference to the inner `Option<T>`, despite it being potentially aliased by a previous `.get()` borrow.

For instance, miri rejects the following code:

```rust
fn main ()
{
    let x = ::once_cell::unsync::OnceCell::new();
    x.set(42).unwrap();
    let at_x = x.get().unwrap(); // --- (shared) borrow of inner `Option<T>` --+
    let _ = x.set(27); // <-- temporary (unique) borrow of inner `Option<T>`   |
    println!("{}", at_x); // <------- up until here ---------------------------+
}
```

Changing the kind of borrow with which the discriminant of `Option<T>` is read to be _shared_, before getting a unique borrow only on the non-`Err`-oring path fixes the issue, as done in this PR.