### PR TITLE
changed `Lazy` to use `FnOnce` instead of `Fn`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,7 @@ pub mod unsync {
         ops::Deref,
         cell::UnsafeCell,
         panic::{UnwindSafe, RefUnwindSafe},
+        hint::unreachable_unchecked
     };
 
     /// A cell which can be written to only once. Not thread safe.
@@ -453,7 +454,7 @@ pub mod unsync {
             this.cell.get_or_init(|| unsafe {
                 match (*this.init.get()).take() {
                     Some(f) => f(),
-                    None => std::hint::unreachable_unchecked()
+                    None => unreachable_unchecked()
                 }
             })
         }
@@ -469,8 +470,11 @@ pub mod unsync {
 
 pub mod sync {
     use crate::imp::OnceCell as Imp;
-    use std::fmt;
-    use std::cell::UnsafeCell;
+    use std::{
+        fmt,
+        cell::UnsafeCell,
+        hint::unreachable_unchecked
+    };
 
     /// A thread-safe cell which can be written to only once.
     ///
@@ -741,7 +745,7 @@ pub mod sync {
             this.cell.get_or_init(|| unsafe {
                 match (*this.init.get()).take() {
                     Some(f) => f(),
-                    None => std::hint::unreachable_unchecked()
+                    None => unreachable_unchecked()
                 }
             })
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,6 @@ pub mod unsync {
         ops::Deref,
         cell::UnsafeCell,
         panic::{UnwindSafe, RefUnwindSafe},
-        mem::ManuallyDrop,
     };
 
     /// A cell which can be written to only once. Not thread safe.
@@ -706,8 +705,6 @@ pub mod sync {
         }
     }
 
-    unsafe impl<T: Send, F: Send> Send for Lazy<T, F> {}
-    
     // We never create a `&F` from a `&Lazy<T, F>` so it is fine
     // to not impl `Sync` for `F`
     // we do create a `&mut Option<F>` in `force`, but this is

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -171,6 +171,7 @@ fn static_lazy_no_macros() {
 fn sync_once_cell_is_sync_send() {
     fn assert_traits<T: Send + Sync>() {}
     assert_traits::<sync::OnceCell<String>>();
+    assert_traits::<sync::Lazy<String>>();
 }
 
 #[test]


### PR DESCRIPTION
This change allows for more ergonomic usage of `Lazy` when embedded in other types or on the stack (not a global `static`). It does this by allowing strictly more types of closures to be used with `Lazy`.