### PR TITLE
Allow non-std version of crate to be used in no_std environments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,11 @@ might be easier to debug than a deadlock.
 
 */
 
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
 #[cfg(feature = "std")]
 #[cfg(feature = "parking_lot")]
 #[path = "imp_pl.rs"]


### PR DESCRIPTION
This changes makes the crate no_std by default and brings in the std crate as an optional dependency. This allows the `unsync` part of the crate to be useable in no_std environments when the `std` feature is disabled.