### PR TITLE
impl Default for Lazy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,6 +537,13 @@ pub mod unsync {
             Lazy::force(self)
         }
     }
+
+    impl<T: Default> Default for Lazy<T> {
+        /// Creates a new lazy value using `Default` as the initializing function.
+        fn default() -> Lazy<T> {
+            Lazy::new(T::default)
+        }
+    }
 }
 
 #[cfg(feature = "std")]
@@ -868,6 +875,13 @@ pub mod sync {
         type Target = T;
         fn deref(&self) -> &T {
             Lazy::force(self)
+        }
+    }
+
+    impl<T: Default> Default for Lazy<T> {
+        /// Creates a new lazy value using `Default` as the initializing function.
+        fn default() -> Lazy<T> {
+            Lazy::new(T::default)
         }
     }
 


### PR DESCRIPTION
Replacing lazy_static in my codebases I've found I'm doing `Lazy::new(<_>::default)` a fair bit generally for Mutex use.

This pr streamlines that to `Lazy::default()`, in a similar way to `Arc`, `Mutex` wrappers. Although it won't work in static contexts, which sucks.