### PR TITLE
add sync::OnceCell::get_unchecked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.0
+
+- add `sync::OnceCell::get_unchecked`.
+
 ## 1.1.0
 
 - implement `Default` for `Lazy`: it creates an empty `Lazy<T>` which is initialized with `T::default` on first access.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "once_cell"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,11 +656,14 @@ pub mod sync {
             unsafe { &mut *self.0.value.get() }.as_mut()
         }
 
-        /// Safety to call if guarded by `initialize`, `is_initialized`
+        /// Get the reference to the underlying value, without checking if the
+        /// cell is initialized.
         ///
-        /// Implementations of those functions in `imp` must provide proper
-        /// synchronization and write-once property
-        unsafe fn get_unchecked(&self) -> &T {
+        /// Safety:
+        ///
+        /// Caller must ensure that the cell is in initialized state.
+        pub unsafe fn get_unchecked(&self) -> &T {
+            debug_assert!(self.0.is_initialized());
             let slot: &Option<T> = &*self.0.value.get();
             match slot {
                 Some(value) => value,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -213,6 +213,15 @@ mod sync {
     }
 
     #[test]
+    fn once_cell_get_unchecked() {
+        let c = OnceCell::new();
+        c.set(92).unwrap();
+        unsafe {
+            assert_eq!(c.get_unchecked(), &92);
+        }
+    }
+
+    #[test]
     fn once_cell_drop() {
         static DROP_CNT: AtomicUsize = AtomicUsize::new(0);
         struct Dropper;


### PR DESCRIPTION
Note that we intentionally don't add
`unsync::OnceCell::get_unchecked`:

* it doesn't do any atomic operations, so should be cheap
* given than it's cheap, there's a chance that `get_unchecked` will be
  misused
* if you absolutely need it, you can `.unwrap_unchecked` on the call
  site