### PR TITLE
Add synchronization note to get_unchecked

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -665,7 +665,8 @@ pub mod sync {
         ///
         /// Safety:
         ///
-        /// Caller must ensure that the cell is in initialized state.
+        /// Caller must ensure that the cell is in initialized state, and that
+        /// the contents are acquired by (synchronized to) this thread.
         pub unsafe fn get_unchecked(&self) -> &T {
             debug_assert!(self.0.is_initialized());
             let slot: &Option<T> = &*self.0.value.get();


### PR DESCRIPTION
The caller not only has to make sure that the cell is initialized, but also that the data is acquired by the current thread. I can't imagine any scenario where you know it is initialized but where you didn't do an acquire yet, but it seems good to document.