### PR TITLE
Use consume

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -1,11 +1,18 @@
+#![feature(test)]
 use std::mem::size_of;
 
-use once_cell::sync::OnceCell;
+extern crate test;
 
-const N_THREADS: usize = 32;
-const N_ROUNDS: usize = 100_000_000;
+use once_cell::sync::OnceCell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use test::black_box;
+
+const N_THREADS: usize = 4;
+const N_ROUNDS: usize = 1_000_000;
 
 static CELL: OnceCell<usize> = OnceCell::new();
+static OTHER: AtomicUsize = AtomicUsize::new(0);
 
 fn main() {
     let start = std::time::Instant::now();
@@ -14,15 +21,25 @@ fn main() {
     for thread in threads {
         thread.join().unwrap();
     }
+    println!("{:?}", OTHER.load(Ordering::Acquire));
     println!("{:?}", start.elapsed());
     println!("size_of::<OnceCell<()>>()   = {:?}", size_of::<OnceCell<()>>());
     println!("size_of::<OnceCell<bool>>() = {:?}", size_of::<OnceCell<bool>>());
     println!("size_of::<OnceCell<u32>>()  = {:?}", size_of::<OnceCell<u32>>());
 }
 
+#[inline(never)]
 fn thread_main(i: usize) {
+    let mut data = [0u32; 100];
+    let mut accum = 0u32;
     for _ in 0..N_ROUNDS {
         let &value = CELL.get_or_init(|| i);
-        assert!(value < N_THREADS)
+        for i in data.iter_mut() {
+            *i = (*i).wrapping_add(accum);
+            accum = accum.wrapping_add(3);
+        }
+        OTHER.fetch_add(1, Ordering::Relaxed);
+        black_box(value);
+        black_box(data);
     }
 }

--- a/examples/break_it.rs
+++ b/examples/break_it.rs
@@ -1,0 +1,35 @@
+/// Test if the OnceCell properly synchronizes.
+/// Needs to be run in release mode.
+///
+/// We create a `Vec` with `N_ROUNDS` of `OnceCell`s. All threads will walk the `Vec`, and race to
+/// be the first one to initialize a cell.
+/// Every thread adds the results of the cells it sees to an accumulator, which is compared at the
+/// end.
+/// All threads should end up with the same result.
+
+use once_cell::sync::OnceCell;
+
+const N_THREADS: usize = 4;
+const N_ROUNDS: usize = 1_000_000;
+
+static CELLS: OnceCell<Vec<OnceCell<usize>>> = OnceCell::new();
+static RESULT: OnceCell<usize> = OnceCell::new();
+
+fn main() {
+    CELLS.get_or_init(|| vec![OnceCell::new(); N_ROUNDS]);
+    let threads =
+        (0..N_THREADS).map(|i| std::thread::spawn(move || thread_main(i))).collect::<Vec<_>>();
+    for thread in threads {
+        thread.join().unwrap();
+    }
+}
+
+fn thread_main(i: usize) {
+    let cells = CELLS.get().unwrap();
+    let mut accum = 0;
+    for cell in cells.iter() {
+        let &value = cell.get_or_init(|| i);
+        accum += value;
+    }
+    assert_eq!(RESULT.get_or_init(|| accum), &accum);
+}

--- a/src/imp_std.rs
+++ b/src/imp_std.rs
@@ -8,7 +8,7 @@ use std::{
     marker::PhantomData,
     panic::{RefUnwindSafe, UnwindSafe},
     ptr,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicIsize, Ordering},
     thread::{self, Thread},
 };
 
@@ -16,7 +16,11 @@ use std::{
 pub(crate) struct OnceCell<T> {
     // This `state` word is actually an encoded version of just a pointer to a
     // `Waiter`, so we add the `PhantomData` appropriately.
-    state: AtomicUsize,
+    // >= 0 INITIALIZED (offset to data)
+    //       -1 EMPTY
+    //       -2 RUNNING
+    //     < -2 (encoded waiter pointer, -(waiterptr >> 1))
+    state: AtomicIsize,
     _marker: PhantomData<*mut Waiter>,
     // FIXME: switch to `std::mem::MaybeUninit` once we are ready to bump MSRV
     // that far. It was stabilized in 1.36.0, so, if you are reading this and
@@ -36,17 +40,12 @@ unsafe impl<T: Send> Send for OnceCell<T> {}
 impl<T: RefUnwindSafe + UnwindSafe> RefUnwindSafe for OnceCell<T> {}
 impl<T: UnwindSafe> UnwindSafe for OnceCell<T> {}
 
-// Three states that a OnceCell can be in, encoded into the lower bits of `state` in
-// the OnceCell structure.
-const INCOMPLETE: usize = 0x0;
-const RUNNING: usize = 0x1;
-const COMPLETE: usize = 0x2;
-
-// Mask to learn about the state. All other bits are the queue of waiters if
-// this is in the RUNNING state.
-const STATE_MASK: usize = 0x3;
+// States that a OnceCell can be in before in is initialized.
+const EMPTY: isize = -1;
+const RUNNING: isize = -2; // and less
 
 // Representation of a node in the linked list of waiters in the RUNNING state.
+#[repr(align(8))]
 struct Waiter {
     thread: Option<Thread>,
     signaled: AtomicBool,
@@ -57,13 +56,13 @@ struct Waiter {
 // implementation to also run on panic.
 struct Finish<'a> {
     failed: bool,
-    my_state: &'a AtomicUsize,
+    my_state: &'a AtomicIsize,
 }
 
 impl<T> OnceCell<T> {
     pub(crate) const fn new() -> OnceCell<T> {
         OnceCell {
-            state: AtomicUsize::new(INCOMPLETE),
+            state: AtomicIsize::new(EMPTY),
             _marker: PhantomData,
             value: UnsafeCell::new(None),
         }
@@ -76,7 +75,7 @@ impl<T> OnceCell<T> {
         // operations visible to us, and, this being a fast path, weaker
         // ordering helps with performance. This `Acquire` synchronizes with
         // `SeqCst` operations on the slow path.
-        self.state.load(Ordering::Acquire) == COMPLETE
+        self.state.load(Ordering::Acquire) >= 0
     }
 
     /// Safety: synchronizes with store to value via SeqCst read from state,
@@ -108,72 +107,70 @@ impl<T> OnceCell<T> {
 }
 
 // Note: this is intentionally monomorphic
-fn initialize_inner(my_state: &AtomicUsize, init: &mut dyn FnMut() -> bool) -> bool {
+fn initialize_inner(my_state: &AtomicIsize, init: &mut dyn FnMut() -> bool) -> bool {
     // This cold path uses SeqCst consistently because the
     // performance difference really does not matter there, and
     // SeqCst minimizes the chances of something going wrong.
     let mut state = my_state.load(Ordering::SeqCst);
 
     'outer: loop {
-        match state {
+        if state >= 0 {
             // If we're complete, then there's nothing to do, we just
             // jettison out as we shouldn't run the closure.
-            COMPLETE => return true,
-
+            return true;
+        } else if state == EMPTY {
             // Otherwise if we see an incomplete state we will attempt to
             // move ourselves into the RUNNING state. If we succeed, then
             // the queue of waiters starts at null (all 0 bits).
-            INCOMPLETE => {
-                let old = my_state.compare_and_swap(state, RUNNING, Ordering::SeqCst);
-                if old != state {
-                    state = old;
-                    continue;
-                }
-
-                // Run the initialization routine, letting it know if we're
-                // poisoned or not. The `Finish` struct is then dropped, and
-                // the `Drop` implementation here is responsible for waking
-                // up other waiters both in the normal return and panicking
-                // case.
-                let mut complete = Finish { failed: true, my_state };
-                let success = init();
-                // Difference from std: abort if `init` errored.
-                complete.failed = !success;
-                return success;
+            let old = my_state.compare_and_swap(state, RUNNING, Ordering::SeqCst);
+            if old != state {
+                state = old;
+                continue;
             }
 
+            // Run the initialization routine, letting it know if we're
+            // poisoned or not. The `Finish` struct is then dropped, and
+            // the `Drop` implementation here is responsible for waking
+            // up other waiters both in the normal return and panicking
+            // case.
+            let mut complete = Finish { failed: true, my_state };
+            let success = init();
+            // Difference from std: abort if `init` errored.
+            complete.failed = !success;
+            return success;
+        } else {
             // All other values we find should correspond to the RUNNING
             // state with an encoded waiter list in the more significant
             // bits. We attempt to enqueue ourselves by moving us to the
             // head of the list and bail out if we ever see a state that's
             // not RUNNING.
-            _ => {
-                assert!(state & STATE_MASK == RUNNING);
-                let mut node = Waiter {
-                    thread: Some(thread::current()),
-                    signaled: AtomicBool::new(false),
-                    next: ptr::null_mut(),
-                };
-                let me = &mut node as *mut Waiter as usize;
-                assert!(me & STATE_MASK == 0);
+            assert!(state <= RUNNING);
+            let mut node = Waiter {
+                thread: Some(thread::current()),
+                signaled: AtomicBool::new(false),
+                next: ptr::null_mut(),
+            };
+            let me = -(((&mut node as *mut Waiter as usize) >> 1) as isize);
 
-                while state & STATE_MASK == RUNNING {
-                    node.next = (state & !STATE_MASK) as *mut Waiter;
-                    let old = my_state.compare_and_swap(state, me | RUNNING, Ordering::SeqCst);
-                    if old != state {
-                        state = old;
-                        continue;
-                    }
-
-                    // Once we've enqueued ourselves, wait in a loop.
-                    // Afterwards reload the state and continue with what we
-                    // were doing from before.
-                    while !node.signaled.load(Ordering::SeqCst) {
-                        thread::park();
-                    }
-                    state = my_state.load(Ordering::SeqCst);
-                    continue 'outer;
+            while state <= RUNNING {
+                if state != RUNNING {
+                    // This is an encoded pointer
+                    node.next = (((-state) as usize) << 1) as *mut Waiter;
                 }
+                let old = my_state.compare_and_swap(state, me, Ordering::SeqCst);
+                if old != state {
+                    state = old;
+                    continue;
+                }
+
+                // Once we've enqueued ourselves, wait in a loop.
+                // Afterwards reload the state and continue with what we
+                // were doing from before.
+                while !node.signaled.load(Ordering::SeqCst) {
+                    thread::park();
+                }
+                state = my_state.load(Ordering::SeqCst);
+                continue 'outer;
             }
         }
     }
@@ -184,25 +181,27 @@ impl Drop for Finish<'_> {
         // Swap out our state with however we finished. We should only ever see
         // an old state which was RUNNING.
         let queue = if self.failed {
-            // Difference from std: flip back to INCOMPLETE rather than POISONED.
-            self.my_state.swap(INCOMPLETE, Ordering::SeqCst)
+            // Difference from std: flip back to EMPTY rather than POISONED.
+            self.my_state.swap(EMPTY, Ordering::SeqCst)
         } else {
-            self.my_state.swap(COMPLETE, Ordering::SeqCst)
+            self.my_state.swap(0, Ordering::SeqCst)
         };
-        assert_eq!(queue & STATE_MASK, RUNNING);
+        assert!(queue <= RUNNING);
 
         // Decode the RUNNING to a list of waiters, then walk that entire list
         // and wake them up. Note that it is crucial that after we store `true`
         // in the node it can be free'd! As a result we load the `thread` to
         // signal ahead of time and then unpark it after the store.
         unsafe {
-            let mut queue = (queue & !STATE_MASK) as *mut Waiter;
-            while !queue.is_null() {
-                let next = (*queue).next;
-                let thread = (*queue).thread.take().unwrap();
-                (*queue).signaled.store(true, Ordering::SeqCst);
-                thread.unpark();
-                queue = next;
+            if queue != RUNNING {
+                let mut queue = ((-queue as usize) << 1) as *mut Waiter;
+                while !queue.is_null() {
+                    let next = (*queue).next;
+                    let thread = (*queue).thread.take().unwrap();
+                    (*queue).signaled.store(true, Ordering::SeqCst);
+                    thread.unpark();
+                    queue = next;
+                }
             }
         }
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -218,6 +218,30 @@ mod sync {
     }
 
     #[test]
+    fn once_cell_large_alignment() {
+        #[repr(align(32))]
+        #[derive(Debug, Eq, PartialEq)]
+        struct MyType(i32);
+
+        let c = OnceCell::new();
+        assert!(c.get().is_none());
+        c.get_or_init(|| MyType(92));
+        assert_eq!(c.get(), Some(&MyType(92)));
+    }
+
+    #[test]
+    fn once_cell_zst() {
+        #[repr(align(32))]
+        #[derive(Debug, Eq, PartialEq)]
+        struct MyType(());
+
+        let c = OnceCell::new();
+        assert!(c.get().is_none());
+        c.get_or_init(|| MyType(()));
+        assert_eq!(c.get(), Some(&MyType(())));
+    }
+
+    #[test]
     fn once_cell_get_mut() {
         let mut c = OnceCell::new();
         assert!(c.get_mut().is_none());


### PR DESCRIPTION
The Atomic ordering consume is meant for data structures that are rarely written but often read. That sounds like a description of `once_cell` :smile:. On all modern processors it can be implemented without using any synchronization fences.

This PR is an experiment, to see if it really gives a performance improvement. This is very much a proof of concept, not cleaned up or intended for merging.

To use consume ordering, there has to be a data dependency between the atomic and the data it synchronizes. In other words: without reading the atomic it must be impossible for this thread to know where the data *lives* that has to be synchronized.

The queue of `Waiters` in the std implementation is a perfect fit: the atomic contains a pointer to the first node, and every node contains a pointer to the next. This is like an example from the book of a data dependency chain that could be used with Consume. But as that part is not performance sensitive, we can just leave it as is.

To create a data dependency of `value` on `state`, I made `state` encode an offset from the address of the `OnceCell` struct to the `value` field. Encoding a raw pointer is not possible, as the `OnceCell` can be moved. This trick relies on the compiler not to change the layout of an initialized struct (which seems like something we can rely on).

Rust doesn't expose an `Ordering::Consume`. But it doesn't need anything special: just using `Ordering::Relaxed` is enough, and is what Crossbeam uses. We just have to next use the atomic as a pointer, array index, pointer offset, etc.

To test the ordering works, I added a `break_it` test in `examples`. It can reliably detect unsufficent synchronization when I run it in release mode on my phone, which is easy using [dinghy](https://github.com/snipsco/dinghy). If I intentionally reduce the synchronization of the current implementation, it will detect a few races. But with consume it works. To make sure it doesn't work by accident, I tuned down all other orderings to the lowest possible for now.

In the existing benchmark that does nothing but read from a `OnceCell` in a loop, there is not any real difference I can measure. In a changed benchmark where all threads also do some work, like writing some data, a difference becomes more clear. This is a result of 10 runs of the modified `bench.rs`:

| x86_64 acquire | x86_64 consume | aarch64 acquire | aarch64 consume |
|---------|---------|---------|---------|
| 171.6ms | 107.5ms | 204.5ms | 155.2ms |
| 158.7ms | 115.4ms | 204.1ms | 179.5ms |
| 184.3ms | 108.0ms | 207.7ms | 156.3ms |
| 107.2ms | 116.3ms | 204.0ms | 181.0ms |
| 143.2ms | 114.3ms | 204.0ms | 181.6ms |
| 164.5ms | 116.5ms | 204.8ms | 154.3ms |
| 113.6ms | 114.8ms | 205.9ms | 157.3ms |
| 107.4ms | 116.1ms | 203.7ms | 155.0ms |
| 181.0ms | 114.6ms | 205.5ms | 177.1ms |
| 176.0ms | 105.2ms | 202.2ms | 155.7ms |

To make `state` in the std implementation encode everything, I set up the following scheme:
```text
>= 0 INITIALIZED (offset to data)
  -1 EMPTY
  -2 RUNNING
< -2 RUNNING, encoded waiter pointer, -(waiterptr >> 1)
```
- One goal was to make the check on whether a `OnceCell` is initialized cheap: just a comparison against zero, with no bitmasks or even another integer to compare against.
- The offset in the initialized case can be any positive number between 0..isize::max. It is doubtful such a large struct can be allocated, let alone to have padding that large! The maximum alignment that can be specified using `#[repr(align)]` is 2^29. And with large alignments, the compiler currently changes the layout of the struct to have `state` after `value`, which gives an offset of 0. Anyway, reserving this whole range seems like a safe enough choice.
- All negative values indicate the `OnceCell` is not initialized. We can control the alignment of the `Waiter` nodes, which I set to 8. This causes the pointer to a `Waiter` node to be in the range 8..usize::max. after encoding it with `-(waiterptr >> 1)` it will be in the range -(4..isize::max). That still leaves -1, -2 and -3 to encode the states EMPTY and RUNNING (without other threads waiting).

I will start cleaning the code up, and add more comments. Don't put too much time in reviewing yet. But I am interested in your opinion! Is this worth pursuing?