### PR TITLE
Use MaybeUninit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ matrix:
     script:
     - cargo build --no-default-features --test test
 
+  - rust: stable
+    script:
+    - cargo test --no-default-features --features "std maybe_uninit"
+    - cargo test --no-default-features --features "std maybe_uninit parking_lot"
+
   - rust: 1.31.1
     script:
     - mv Cargo.lock.min Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ regex =  "1.2.0"
 default = ["std"]
 # Enables `once_cell::sync` module.
 std = []
+# Use `MaybeUninit` in the `sync` module.
+maybe_uninit = []
 
 [[example]]
 name = "bench"

--- a/src/imp_pl.rs
+++ b/src/imp_pl.rs
@@ -1,9 +1,9 @@
 use std::{
     cell::UnsafeCell,
-    mem::MaybeUninit,
     panic::{RefUnwindSafe, UnwindSafe},
     sync::atomic::{AtomicBool, Ordering},
 };
+use crate::maybe_uninit::MaybeUninit;
 
 use parking_lot::{lock_api::RawMutex as _RawMutex, RawMutex};
 
@@ -59,7 +59,8 @@ impl<T> OnceCell<T> {
             let value = f()?;
             unsafe {
                 let slot: &mut MaybeUninit<T> = &mut *self.value.get();
-                slot.as_mut_ptr().write(value);
+                // FIXME: replace with `slot.as_mut_ptr().write(value)`
+                slot.write(value);
             }
             self.is_initialized.store(true, Ordering::Release);
         }

--- a/src/imp_pl.rs
+++ b/src/imp_pl.rs
@@ -95,9 +95,8 @@ impl Drop for MutexGuard<'_> {
 }
 
 #[test]
-#[cfg(target_pointer_width = "64")]
 fn test_size() {
     use std::mem::size_of;
 
-    assert_eq!(size_of::<OnceCell<u32>>(), 3 * size_of::<u32>());
+    assert_eq!(size_of::<OnceCell<bool>>(), 3 * size_of::<u8>());
 }

--- a/src/imp_std.rs
+++ b/src/imp_std.rs
@@ -315,10 +315,9 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
     fn test_size() {
         use std::mem::size_of;
 
-        assert_eq!(size_of::<OnceCell<u32>>(), 4 * size_of::<u32>());
+        assert_eq!(size_of::<OnceCell<&usize>>(), 2 * size_of::<usize>());
     }
 }

--- a/src/imp_std.rs
+++ b/src/imp_std.rs
@@ -5,12 +5,12 @@
 
 use std::{
     cell::{Cell, UnsafeCell},
-    mem::MaybeUninit,
     marker::PhantomData,
     panic::{RefUnwindSafe, UnwindSafe},
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     thread::{self, Thread},
 };
+use crate::maybe_uninit::MaybeUninit;
 
 pub(crate) struct OnceCell<T> {
     // This `state` word is actually an encoded version of just a pointer to a
@@ -93,7 +93,8 @@ impl<T> OnceCell<T> {
                 Ok(value) => {
                     unsafe {
                         let slot: &mut MaybeUninit<T> = &mut *slot.get();
-                        slot.as_mut_ptr().write(value);
+                        // FIXME: replace with `slot.as_mut_ptr().write(value)`
+                        slot.write(value);
                     }
                     true
                 }

--- a/src/imp_std.rs
+++ b/src/imp_std.rs
@@ -5,23 +5,19 @@
 
 use std::{
     cell::{Cell, UnsafeCell},
+    mem::MaybeUninit,
     marker::PhantomData,
     panic::{RefUnwindSafe, UnwindSafe},
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     thread::{self, Thread},
 };
 
-#[derive(Debug)]
 pub(crate) struct OnceCell<T> {
     // This `state` word is actually an encoded version of just a pointer to a
     // `Waiter`, so we add the `PhantomData` appropriately.
     state_and_queue: AtomicUsize,
     _marker: PhantomData<*mut Waiter>,
-    // FIXME: switch to `std::mem::MaybeUninit` once we are ready to bump MSRV
-    // that far. It was stabilized in 1.36.0, so, if you are reading this and
-    // it's higher than 1.46.0 outside, please send a PR! ;) (and do the same
-    // for `Lazy`, while we are at it).
-    pub(crate) value: UnsafeCell<Option<T>>,
+    pub(crate) value: UnsafeCell<MaybeUninit<T>>,
 }
 
 // Why do we need `T: Send`?
@@ -66,7 +62,7 @@ impl<T> OnceCell<T> {
         OnceCell {
             state_and_queue: AtomicUsize::new(INCOMPLETE),
             _marker: PhantomData,
-            value: UnsafeCell::new(None),
+            value: UnsafeCell::new(MaybeUninit::uninit()),
         }
     }
 
@@ -95,7 +91,10 @@ impl<T> OnceCell<T> {
             let f = f.take().unwrap();
             match f() {
                 Ok(value) => {
-                    unsafe { *slot.get() = Some(value) };
+                    unsafe {
+                        let slot: &mut MaybeUninit<T> = &mut *slot.get();
+                        slot.as_mut_ptr().write(value);
+                    }
                     true
                 }
                 Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,7 +570,7 @@ pub mod sync {
     use std::{
         cell::Cell,
         fmt,
-        hint::unreachable_unchecked,
+        mem::MaybeUninit,
         ops::{Deref, DerefMut},
         panic::RefUnwindSafe,
     };
@@ -675,7 +675,11 @@ pub mod sync {
         /// Returns `None` if the cell is empty.
         pub fn get_mut(&mut self) -> Option<&mut T> {
             // Safe b/c we have a unique access.
-            unsafe { &mut *self.0.value.get() }.as_mut()
+            if self.0.is_initialized() {
+                Some(unsafe { &mut *(*self.0.value.get()).as_mut_ptr() })
+            } else {
+                None
+            }
         }
 
         /// Get the reference to the underlying value, without checking if the
@@ -687,15 +691,8 @@ pub mod sync {
         /// the contents are acquired by (synchronized to) this thread.
         pub unsafe fn get_unchecked(&self) -> &T {
             debug_assert!(self.0.is_initialized());
-            let slot: &Option<T> = &*self.0.value.get();
-            match slot {
-                Some(value) => value,
-                // This unsafe does improve performance, see `examples/bench`.
-                None => {
-                    debug_assert!(false);
-                    unreachable_unchecked()
-                }
-            }
+            let slot: &MaybeUninit<T> = &*self.0.value.get();
+            &*slot.as_ptr()
         }
 
         /// Sets the contents of this cell to `value`.
@@ -825,7 +822,13 @@ pub mod sync {
         pub fn into_inner(self) -> Option<T> {
             // Because `into_inner` takes `self` by value, the compiler statically verifies
             // that it is not currently borrowed. So it is safe to move out `Option<T>`.
-            self.0.value.into_inner()
+            if self.0.is_initialized() {
+                unsafe {
+                    Some(self.0.value.into_inner().assume_init())
+                }
+            } else {
+                None
+            }
         }
     }
 
@@ -863,6 +866,7 @@ pub mod sync {
     /// ```
     pub struct Lazy<T, F = fn() -> T> {
         cell: OnceCell<T>,
+        // FIXME: replace with MaybeUninit
         init: Cell<Option<F>>,
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,8 @@ mod imp;
 #[path = "imp_std.rs"]
 mod imp;
 
+mod maybe_uninit;
+
 pub mod unsync {
     use core::{
         cell::{Cell, UnsafeCell},
@@ -570,12 +572,13 @@ pub mod sync {
     use std::{
         cell::{Cell, UnsafeCell},
         fmt,
-        mem::{self, ManuallyDrop, MaybeUninit},
+        mem::{self, ManuallyDrop},
         ops::{Deref, DerefMut},
         panic::RefUnwindSafe,
     };
 
     use crate::imp::OnceCell as Imp;
+    use crate::maybe_uninit::MaybeUninit;
 
     /// A thread-safe cell which can be written to only once.
     ///

--- a/src/maybe_uninit.rs
+++ b/src/maybe_uninit.rs
@@ -1,0 +1,85 @@
+//! This module contains a re-export or vendored version of `core::mem::MaybeUninit` depending
+//! on which Rust version it's compiled for.
+//!
+//! Remove this module and use `core::mem::MaybeUninit` directly when dropping support for <1.36
+
+/// This is a terrible imitation of `core::mem::MaybeUninit` to support Rust older than 1.36.
+/// Differences from the real deal:
+/// - We drop the values contained in `MaybeUninit`, while that has to be done manually otherwise;
+/// - We use more memory;
+/// - `as_mut_ptr()` can't be used to initialize the `MaybeUninit`.
+
+#[cfg(feature = "maybe_uninit")]
+pub struct MaybeUninit<T>(core::mem::MaybeUninit<T>);
+
+#[cfg(feature = "maybe_uninit")]
+impl<T> MaybeUninit<T> {
+    #[inline]
+    pub const fn uninit() -> MaybeUninit<T> {
+        MaybeUninit(core::mem::MaybeUninit::uninit())
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        self.0.as_ptr()
+    }
+
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.0.as_mut_ptr()
+    }
+
+    // Emulate `write`, which is only available on nightly.
+    #[inline]
+    pub unsafe fn write(&mut self, value: T) -> &mut T {
+        let slot = self.0.as_mut_ptr();
+        slot.write(value);
+        &mut *slot
+    }
+
+    #[inline]
+    pub unsafe fn assume_init(self) -> T {
+        self.0.assume_init()
+    }
+}
+
+
+#[cfg(not(feature = "maybe_uninit"))]
+pub struct MaybeUninit<T>(Option<T>);
+
+#[cfg(not(feature = "maybe_uninit"))]
+impl<T> MaybeUninit<T> {
+    #[inline]
+    pub const fn uninit() -> MaybeUninit<T> {
+        MaybeUninit(None)
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        match self.0.as_ref() {
+            Some(value) => value,
+            None => {
+                // This unsafe does improve performance, see `examples/bench`.
+                debug_assert!(false);
+                unsafe { core::hint::unreachable_unchecked() }
+            }
+        }
+    }
+
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.0.as_mut().unwrap()
+    }
+
+    // It would be better to use `as_mut_ptr().write()`, but that can't be emulated with `Option`.
+    #[inline]
+    pub unsafe fn write(&mut self, val: T) -> &mut T {
+        self.0 = Some(val);
+        self.0.as_mut().unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn assume_init(self) -> T {
+        self.0.unwrap()
+    }
+}


### PR DESCRIPTION
Replace `UnsafeCell<Option<T>>` with `UnsafeCell<MaybeUninit<T>>`.

I included a terrible imitation of `MaybeUninit` based on `Option`, so there is no change in behavior right now. The real implementation that uses `std::mem::MaybeUninit` is behind a feature flag `maybe_uninit` and only usable with nightly.

I did find one complexity: `OnceCell` now has to implement `Drop` itself. Therefore it has to check `is_initialized`. `into_inner` now has to use the `mem::replace` trick to move the `value` field out of the `OnceCell`, and then free the cell without dropping (because `initialized` is not reset).

Conclusion: a bit messy. But I think it makes sense, as a preparation for the future. And it is a plus that `is_initialized` is now the single source of truth.