### PR TITLE
Add poisoning

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -22,7 +22,7 @@ fn main() {
 
 fn thread_main(i: usize) {
     for _ in 0..N_ROUNDS {
-        let &value = CELL.get_or_init(|| i);
+        let &value = CELL.get_or_init(|_| i);
         assert!(value < N_THREADS)
     }
 }

--- a/examples/bench_acquire.rs
+++ b/examples/bench_acquire.rs
@@ -29,7 +29,7 @@ fn thread_main(i: usize) {
     let mut data = [i; 128];
     let mut accum = 0usize;
     for _ in 0..N_ROUNDS {
-        let _value = CELL.get_or_init(|| i+1);
+        let _value = CELL.get_or_init(|_| i+1);
         let k = OTHER.fetch_add(data[accum & 0x7F] as usize, Ordering::Relaxed);
         for j in data.iter_mut() {
             *j = (*j).wrapping_add(accum);

--- a/examples/bench_vs_lazy_static.rs
+++ b/examples/bench_vs_lazy_static.rs
@@ -4,7 +4,7 @@ use once_cell::sync::Lazy;
 const N_THREADS: usize = 32;
 const N_ROUNDS: usize = 100_000_000;
 
-static ONCE_CELL: Lazy<Vec<String>> = Lazy::new(|| vec!["Spica".to_string(), "Hoyten".to_string()]);
+static ONCE_CELL: Lazy<Vec<String>> = Lazy::new(|_| vec!["Spica".to_string(), "Hoyten".to_string()]);
 
 lazy_static! {
     static ref LAZY_STATIC: Vec<String> = vec!["Spica".to_string(), "Hoyten".to_string()];

--- a/examples/lazy_static.rs
+++ b/examples/lazy_static.rs
@@ -3,7 +3,7 @@ extern crate once_cell;
 use once_cell::sync::{Lazy, OnceCell};
 use std::collections::HashMap;
 
-static HASHMAP: Lazy<HashMap<u32, &'static str>> = Lazy::new(|| {
+static HASHMAP: Lazy<HashMap<u32, &'static str>> = Lazy::new(|_| {
     let mut m = HashMap::new();
     m.insert(0, "foo");
     m.insert(1, "bar");

--- a/examples/lazy_static.rs
+++ b/examples/lazy_static.rs
@@ -14,7 +14,7 @@ static HASHMAP: Lazy<HashMap<u32, &'static str>> = Lazy::new(|| {
 // Same, but completely without macros
 fn hashmap() -> &'static HashMap<u32, &'static str> {
     static INSTANCE: OnceCell<HashMap<u32, &'static str>> = OnceCell::new();
-    INSTANCE.get_or_init(|| {
+    INSTANCE.get_or_init(|_| {
         let mut m = HashMap::new();
         m.insert(0, "foo");
         m.insert(1, "bar");

--- a/examples/reentrant_init_deadlocks.rs
+++ b/examples/reentrant_init_deadlocks.rs
@@ -1,7 +1,7 @@
 fn main() {
     let cell = once_cell::sync::OnceCell::<u32>::new();
-    cell.get_or_init(|| {
-        cell.get_or_init(|| 1);
+    cell.get_or_init(|_| {
+        cell.get_or_init(|_| 1);
         2
     });
 }

--- a/examples/regex.rs
+++ b/examples/regex.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 macro_rules! regex {
     ($re:literal $(,)?) => {{
         static RE: once_cell::sync::OnceCell<regex::Regex> = once_cell::sync::OnceCell::new();
-        RE.get_or_init(|| regex::Regex::new($re).unwrap())
+        RE.get_or_init(|_| regex::Regex::new($re).unwrap())
     }};
 }
 

--- a/examples/test_synchronization.rs
+++ b/examples/test_synchronization.rs
@@ -17,7 +17,7 @@ static RESULT: OnceCell<usize> = OnceCell::new();
 
 fn main() {
     let start = std::time::Instant::now();
-    CELLS.get_or_init(|| vec![OnceCell::new(); N_ROUNDS]);
+    CELLS.get_or_init(|_| vec![OnceCell::new(); N_ROUNDS]);
     let threads =
         (0..N_THREADS).map(|i| std::thread::spawn(move || thread_main(i))).collect::<Vec<_>>();
     for thread in threads {
@@ -31,8 +31,8 @@ fn thread_main(i: usize) {
     let cells = CELLS.get().unwrap();
     let mut accum = 0;
     for cell in cells.iter() {
-        let &value = cell.get_or_init(|| i);
+        let &value = cell.get_or_init(|_| i);
         accum += value;
     }
-    assert_eq!(RESULT.get_or_init(|| accum), &accum);
+    assert_eq!(RESULT.get_or_init(|_| accum), &accum);
 }

--- a/src/imp_pl.rs
+++ b/src/imp_pl.rs
@@ -43,7 +43,7 @@ impl<T> OnceCell<T> {
     #[cold]
     pub(crate) fn initialize<F, E>(&self, f: F) -> Result<(), E>
     where
-        F: FnOnce() -> Result<T, E>,
+        F: FnOnce(bool) -> Result<T, E>,
     {
         let _guard = self.mutex.lock();
         if !self.is_initialized() {
@@ -55,7 +55,7 @@ impl<T> OnceCell<T> {
             //   but that is more complicated
             // - finally, if it returns Ok, we store the value and store the flag with
             //   `Release`, which synchronizes with `Acquire`s.
-            let value = f()?;
+            let value = f(false)?; // FIXME: do proper poisoning
             let slot: &mut Option<T> = unsafe { &mut *self.value.get() };
             debug_assert!(slot.is_none());
             *slot = Some(value);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -366,7 +366,7 @@ mod sync {
     #[test]
     fn lazy_new() {
         let called = AtomicUsize::new(0);
-        let x = Lazy::new(|| {
+        let x = Lazy::new(|_| {
             called.fetch_add(1, SeqCst);
             92
         });
@@ -415,7 +415,7 @@ mod sync {
     #[test]
     #[cfg(not(miri))] // leaks memory
     fn static_lazy() {
-        static XS: Lazy<Vec<i32>> = Lazy::new(|| {
+        static XS: Lazy<Vec<i32>> = Lazy::new(|_| {
             let mut xs = Vec::new();
             xs.push(1);
             xs.push(2);
@@ -450,7 +450,7 @@ mod sync {
     #[test]
     #[cfg(not(miri))] // miri doesn't support panics
     fn lazy_poisoning() {
-        let x: Lazy<String> = Lazy::new(|| panic!("kaboom"));
+        let x: Lazy<String> = Lazy::new(|_| panic!("kaboom"));
         for _ in 0..2 {
             let res = std::panic::catch_unwind(|| x.len());
             assert!(res.is_err());


### PR DESCRIPTION
Again an experiment, to see the effects of https://github.com/rust-lang/rfcs/pull/2788#discussion_r342484357.

This way of adding poisoning to `OnceCell` and `Lazy` seems not all that invasive to me, however it is a large breaking change.

The compiler is usually very helpful with its error message:
```
   --> tests/test.rs:211:19
    |
211 |                 c.get_or_init(|| 92);
    |                   ^^^^^^^^^^^ -- takes 0 arguments
    |                   |
    |                   expected closure that takes 1 argument
    |
help: consider changing the closure to take and ignore the expected argument
    |
211 |                 c.get_or_init(|_| 92);
    |  
```

Except when there are manual dereferences of a `Lazy`:
```
error[E0614]: type `once_cell::sync::Lazy<_, [closure@tests/test.rs:369:27: 372:10 called:_]>` cannot be dereferenced
   --> tests/test.rs:378:25
    |
378 |                 let y = *x - 30;
    |  
```

I only did the `sync` types for now, and also didn't do the `parking_lot` implementation properly.