### PR TITLE
Add sync::OnceCell::prev_init_panicked method

### DIFF
--- a/src/imp_pl.rs
+++ b/src/imp_pl.rs
@@ -1,14 +1,14 @@
 use std::{
     cell::UnsafeCell,
     panic::{RefUnwindSafe, UnwindSafe},
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicU8, Ordering},
 };
 
 use parking_lot::{lock_api::RawMutex as _RawMutex, RawMutex};
 
 pub(crate) struct OnceCell<T> {
     mutex: Mutex,
-    is_initialized: AtomicBool,
+    state: AtomicU8,
     pub(crate) value: UnsafeCell<Option<T>>,
 }
 
@@ -23,11 +23,21 @@ unsafe impl<T: Send> Send for OnceCell<T> {}
 impl<T: RefUnwindSafe + UnwindSafe> RefUnwindSafe for OnceCell<T> {}
 impl<T: UnwindSafe> UnwindSafe for OnceCell<T> {}
 
+// States that a OnceCell can be in
+const INCOMPLETE: u8 = 0x0;
+const POISONED: u8 = 0x1;
+const COMPLETE: u8 = 0x3;
+
+struct Finalize<'a> {
+    state: &'a AtomicU8,
+    set_state_on_drop_to: u8,
+}
+
 impl<T> OnceCell<T> {
     pub(crate) const fn new() -> OnceCell<T> {
         OnceCell {
             mutex: Mutex::new(),
-            is_initialized: AtomicBool::new(false),
+            state: AtomicU8::new(INCOMPLETE),
             value: UnsafeCell::new(None),
         }
     }
@@ -35,10 +45,10 @@ impl<T> OnceCell<T> {
     /// Safety: synchronizes with store to value via Release/Acquire.
     #[inline]
     pub(crate) fn is_initialized(&self) -> bool {
-        self.is_initialized.load(Ordering::Acquire)
+        self.state.load(Ordering::Acquire) == COMPLETE
     }
 
-    /// Safety: synchronizes with store to value via `is_initialized` or mutex
+    /// Safety: synchronizes with store to value via `state` or mutex
     /// lock/unlock, writes value only once because of the mutex.
     #[cold]
     pub(crate) fn initialize<F, E>(&self, f: F) -> Result<(), E>
@@ -55,13 +65,34 @@ impl<T> OnceCell<T> {
             //   but that is more complicated
             // - finally, if it returns Ok, we store the value and store the flag with
             //   `Release`, which synchronizes with `Acquire`s.
-            let value = f()?;
+            let mut finalizer = Finalize {
+                state: &self.state,
+                set_state_on_drop_to: POISONED,
+            };
+            let value = match f() {
+                Ok(x) => x,
+                Err(e) => {
+                    finalizer.set_state_on_drop_to = INCOMPLETE;
+                    return Err(e);
+                }
+            };
             let slot: &mut Option<T> = unsafe { &mut *self.value.get() };
             debug_assert!(slot.is_none());
             *slot = Some(value);
-            self.is_initialized.store(true, Ordering::Release);
+            finalizer.set_state_on_drop_to = COMPLETE;
         }
         Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn is_poisoned(&self) -> bool {
+        self.state.load(Ordering::Relaxed) == POISONED
+    }
+}
+
+impl Drop for Finalize<'_> {
+    fn drop(&mut self) {
+        self.state.store(self.set_state_on_drop_to, Ordering::Release);
     }
 }
 


### PR DESCRIPTION
I am interested about your opinion about an `prev_init_panicked` method (not attached to the name).

If we don't want to give guarantees about side effects, it is not possible to implement poisoning with user code. Even `sync::Lazy` relies on side effects to synchronize its `Cell<Option<F>>`.

I still think it is the right choice to have `OnceCell` act as if there is no poisoning in the common case is a good default, as it matches what you care about: initialization, not upholding some variant as running exactly once.

For `std` the changes to the implementation are minimal.

For the `parking_lot` implementation I had to go with the same pattern to use a finalizer that sets the appropriate state on panic/err/success. To keep the size of `OnceCell` the same as before, I used an `AtomicU8` which bumps the MSRV for the `parking_lot` feature to 1.34.