### PR TITLE
miri: enable leakcheck

### DIFF
--- a/run-miri-tests.sh
+++ b/run-miri-tests.sh
@@ -8,6 +8,4 @@ rustup toolchain add "$MIRI_NIGHTLY"
 rustup component add miri --toolchain "$MIRI_NIGHTLY"
 rustup run "$MIRI_NIGHTLY" -- cargo miri setup
 
-# Miri considers runtime-allocated data in statics as leaked, so we
-# have to ignore leeks. See <https://github.com/rust-lang/miri/issues/940>.
-rustup run "$MIRI_NIGHTLY" -- cargo miri test -- -Zmiri-ignore-leaks
+rustup run "$MIRI_NIGHTLY" -- cargo miri test

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -448,7 +448,6 @@ mod sync {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // leaks memory
     fn static_lazy() {
         static XS: Lazy<Vec<i32>> = Lazy::new(|| {
             let mut xs = Vec::new();
@@ -467,7 +466,6 @@ mod sync {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // leaks memory
     fn static_lazy_via_fn() {
         fn xs() -> &'static Vec<i32> {
             static XS: OnceCell<Vec<i32>> = OnceCell::new();


### PR DESCRIPTION
https://github.com/rust-lang/miri/issues/940 is fixed, so we should be able to enable the leak checker now. :)

(However, we'll have to wait until https://github.com/rust-lang/rust/pull/70897 lands so that this is available via rustup.)