### PR TITLE
Remove height attribute from logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="design/logo.png" alt="once_cell" height="300px"></p>
+<p align="center"><img src="design/logo.png" alt="once_cell"></p>
 
 
 [![Build Status](https://travis-ci.org/matklad/once_cell.svg?branch=master)](https://travis-ci.org/matklad/once_cell)


### PR DESCRIPTION
I noticed this problem in rust-lang/crates.io#2732 and thought it was a problem on crates.io’s side, but actually the problem is here! Here are two videos showing what the README looks like before the fix and after:

- [Before](https://streamable.com/lhizhp)
- [After](https://streamable.com/k6ygzj)