### PR TITLE
Add Lazy::into_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.6.0
 
+- Add `Lazy::into_value`
 - Stabilize `once_cell::race` module for "first one wins" no_std-compatible initialization flavor.
 - Migrate from deprecated `compare_and_swap` to `compare_exchange`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "once_cell"
-version = "1.5.2"
+version = "1.6.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -599,6 +599,17 @@ pub mod unsync {
         pub const fn new(init: F) -> Lazy<T, F> {
             Lazy { cell: OnceCell::new(), init: Cell::new(Some(init)) }
         }
+
+        /// Consumes this `Lazy` returning the stored value.
+        ///
+        /// Returns `Ok(value)` if `Lazy` is initialized and `Err(f)` otherwise.
+        pub fn into_value(this: Lazy<T, F>) -> Result<T, F> {
+            let cell = this.cell;
+            let init = this.init;
+            cell.into_inner().ok_or_else(|| {
+                init.take().unwrap_or_else(|| panic!("Lazy instance has previously been poisoned"))
+            })
+        }
     }
 
     impl<T, F: FnOnce() -> T> Lazy<T, F> {
@@ -979,6 +990,17 @@ pub mod sync {
         /// function.
         pub const fn new(f: F) -> Lazy<T, F> {
             Lazy { cell: OnceCell::new(), init: Cell::new(Some(f)) }
+        }
+
+        /// Consumes this `Lazy` returning the stored value.
+        ///
+        /// Returns `Ok(value)` if `Lazy` is initialized and `Err(f)` otherwise.
+        pub fn into_value(this: Lazy<T, F>) -> Result<T, F> {
+            let cell = this.cell;
+            let init = this.init;
+            cell.into_inner().ok_or_else(|| {
+                init.take().unwrap_or_else(|| panic!("Lazy instance has previously been poisoned"))
+            })
         }
     }
 

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -156,6 +156,15 @@ mod unsync {
     }
 
     #[test]
+    fn lazy_into_value() {
+        let l: Lazy<i32, _> = Lazy::new(|| panic!());
+        assert!(matches!(Lazy::into_value(l), Err(_)));
+        let l = Lazy::new(|| -> i32 { 92 });
+        Lazy::force(&l);
+        assert!(matches!(Lazy::into_value(l), Ok(92)));
+    }
+
+    #[test]
     #[cfg(feature = "std")]
     fn lazy_poisoning() {
         let x: Lazy<String> = Lazy::new(|| panic!("kaboom"));
@@ -465,6 +474,15 @@ mod sync {
             })
         }
         assert_eq!(xs(), &vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn lazy_into_value() {
+        let l: Lazy<i32, _> = Lazy::new(|| panic!());
+        assert!(matches!(Lazy::into_value(l), Err(_)));
+        let l = Lazy::new(|| -> i32 { 92 });
+        Lazy::force(&l);
+        assert!(matches!(Lazy::into_value(l), Ok(92)));
     }
 
     #[test]


### PR DESCRIPTION
This API allows to move a T out of `Lazy<T>`.
Note that it requires an owned access to a `Lazy` -- there's no way to
reset a lazy to uninit state via `&mut Lazy<T>`, as the init function
is gone. In other words, `fn take(this: &mut Lazy<T>)` is an
impossible object.