### PR TITLE
Convert race to a default-enabled feature for targets without atomics.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,9 @@ default = ["std"]
 # Enables `once_cell::sync` module.
 std = ["alloc"]
 # Enables `once_cell::race::OnceBox` type.
-alloc = []
+alloc = ["race"]
+# Enables `once_cell::race` module.
+race = []
 # Enables semver-exempt APIs of this crate.
 # At the moment, this feature is unused.
 unstable = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1065,4 +1065,5 @@ pub mod sync {
     fn _dummy() {}
 }
 
+#[cfg(feature = "race")]
 pub mod race;

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -589,7 +589,7 @@ mod sync {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(all(feature = "unstable", feature = "race"))]
 mod race {
     use std::{
         num::NonZeroUsize,


### PR DESCRIPTION
 Closes #136.