### PR TITLE
Improve `imp_pl` size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.1
 
 - Fix `race::OnceBox<T>` to also impl `Default` even if `T` doesn't impl `Default`.
+- Improve code size.
 
 ## 1.7.0
 

--- a/src/imp_pl.rs
+++ b/src/imp_pl.rs
@@ -111,6 +111,7 @@ impl<T> OnceCell<T> {
     }
 }
 
+// Note: this is intentionally monomorphic
 #[inline(never)]
 fn initialize_inner(mutex: &Mutex<()>, is_initialized: &AtomicBool, init: &mut dyn FnMut() -> bool) {
     let _guard = mutex.lock();


### PR DESCRIPTION
I have observed that the program size has increased a lot after enabling the `parking_lot` feature.

`parking_lot` will actively inline methods, which leads to some unnecessary duplication of code. see https://github.com/Amanieu/parking_lot/pull/236

This PR introduces an `InlineLessRawMutex` wrapper to avoid this problem. `initialize` is a cold path, I don't think this will cause performance problems.