### PR TITLE
Return value from `set`

### DIFF
--- a/tests/it.rs
+++ b/tests/it.rs
@@ -205,6 +205,13 @@ mod unsync {
             cell.set(&s).unwrap();
         }
     }
+
+    #[test]
+    fn set_and_get() {
+        let c = OnceCell::new();
+        assert_eq!(c.set_and_get(90), Ok(&90));
+        assert_eq!(c.set_and_get(50), Err(50));
+    }
 }
 
 #[cfg(feature = "std")]
@@ -586,6 +593,13 @@ mod sync {
             let s = String::new();
             cell.set(&s).unwrap();
         }
+    }
+
+    #[test]
+    fn set_and_get() {
+        let c = OnceCell::new();
+        assert_eq!(c.set_and_get(90), Ok(&90));
+        assert_eq!(c.set_and_get(50), Err(50));
     }
 }
 


### PR DESCRIPTION
This adds a function called `set_and_get` that returns the value on setting it.
Originally I wanted to implement it only for `sync`, because the value was just being discarded, see the comment I added to `unsync::OnceCell::set_and_get`.

Is there interest in a feature like this?

EDIT:
My use case is to initialize but return an `Err` if it already is initialized. This can be done by calling `OnceCell::set` and then `OnceCell::get`, this offers an optimization, that culls this to only one function call.
This can't be solved by using `OnceCell::get_or_init` because it doesn't offer any indication if it was already set.