### PR TITLE
Add an atomic-polyfill optional dependancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9
+
+- Added an `atomic-polyfill` optional dependency to compile `race` on platforms without atomics
+
 ## 1.8.0
 
 - Add `try_insert` API -- a version of `set` that returns a reference.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
@@ -25,7 +25,10 @@ members = ["xtask"]
 parking_lot = { version = "0.11", optional = true, default_features = false }
 
 # To be used in order to enable the race feature on targets
-# that doe not have atomic
+# that do not have atomics
+# *Warning:* This can be unsound. Please read the README of
+# [atomic-polyfill](https://github.com/embassy-rs/atomic-polyfill)
+# and make sure you understand all the implications
 atomic-polyfill = { version = "0.1", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ members = ["xtask"]
 # for up to 16 bytes smaller, depending on the size of the T.
 parking_lot = { version = "0.11", optional = true, default_features = false }
 
+# To be used in order to enable the race feature on targets
+# that doe not have atomic
+atomic-polyfill = { version = "0.1", optional = true }
+
 [dev-dependencies]
 lazy_static = "1.0.0"
 crossbeam-utils = "0.7.2"


### PR DESCRIPTION
To make it compile on platform that have limited atomics

Fixes #155 

Note that this re-implement the Debug version of the OnceBox
because atomic-polyfill::AtomicPtr don't implement Debug (https://github.com/embassy-rs/atomic-polyfill/issues/11)