### PR TITLE
doc: fix a typo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,7 +482,7 @@ pub mod unsync {
             }
         }
 
-        /// Like [`set`](Self::set), but also returns a referce to the final cell value.
+        /// Like [`set`](Self::set), but also returns a reference to the final cell value.
         ///
         /// # Example
         /// ```


### PR DESCRIPTION
Fix a found typo when skimming through the `once_cell` documentation.