### PR TITLE
Add `OnceCell::with_value` and improve `Clone` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.11
+
+- Add `OnceCell::with_value` to create initialized `OnceCell` at compile time.
+- Improve `Clone` implementation for `OnceCell`.
+
 ## 1.10
 
 - upgrade `parking_lot` to `0.12.0` (note that this bumps MSRV with `parking_lot` feature enabled to `1.49.0`).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ atomic-polyfill = { version = "0.1", optional = true }
 
 [dev-dependencies]
 lazy_static = "1.0.0"
-crossbeam-utils = "0.7.2"
+crossbeam-utils = "0.8.7"
 regex =  "1.2.0"
 
 [features]

--- a/src/imp_std.rs
+++ b/src/imp_std.rs
@@ -69,6 +69,14 @@ impl<T> OnceCell<T> {
         }
     }
 
+    pub(crate) const fn with_value(value: T) -> OnceCell<T> {
+        OnceCell {
+            state_and_queue: AtomicUsize::new(COMPLETE),
+            _marker: PhantomData,
+            value: UnsafeCell::new(Some(value)),
+        }
+    }
+
     /// Safety: synchronizes with store to value via Release/(Acquire|SeqCst).
     #[inline]
     pub(crate) fn is_initialized(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,6 +404,13 @@ pub mod unsync {
                 None => OnceCell::new(),
             }
         }
+
+        fn clone_from(&mut self, source: &Self) {
+            match (self.get_mut(), source.get()) {
+                (Some(this), Some(source)) => this.clone_from(source),
+                _ => *self = source.clone(),
+            }
+        }
     }
 
     impl<T: PartialEq> PartialEq for OnceCell<T> {
@@ -814,6 +821,13 @@ pub mod sync {
             match self.get() {
                 Some(value) => Self::with_value(value.clone()),
                 None => Self::new(),
+            }
+        }
+
+        fn clone_from(&mut self, source: &Self) {
+            match (self.get_mut(), source.get()) {
+                (Some(this), Some(source)) => this.clone_from(source),
+                _ => *self = source.clone(),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,14 +399,10 @@ pub mod unsync {
 
     impl<T: Clone> Clone for OnceCell<T> {
         fn clone(&self) -> OnceCell<T> {
-            let res = OnceCell::new();
-            if let Some(value) = self.get() {
-                match res.set(value.clone()) {
-                    Ok(()) => (),
-                    Err(_) => unreachable!(),
-                }
+            match self.get() {
+                Some(value) => OnceCell::with_value(value.clone()),
+                None => OnceCell::new(),
             }
-            res
         }
     }
 
@@ -420,7 +416,7 @@ pub mod unsync {
 
     impl<T> From<T> for OnceCell<T> {
         fn from(value: T) -> Self {
-            OnceCell { inner: UnsafeCell::new(Some(value)) }
+            OnceCell::with_value(value)
         }
     }
 
@@ -428,6 +424,11 @@ pub mod unsync {
         /// Creates a new empty cell.
         pub const fn new() -> OnceCell<T> {
             OnceCell { inner: UnsafeCell::new(None) }
+        }
+
+        /// Creates a new initialized cell.
+        pub const fn with_value(value: T) -> OnceCell<T> {
+            OnceCell { inner: UnsafeCell::new(Some(value)) }
         }
 
         /// Gets a reference to the underlying value.
@@ -810,22 +811,16 @@ pub mod sync {
 
     impl<T: Clone> Clone for OnceCell<T> {
         fn clone(&self) -> OnceCell<T> {
-            let res = OnceCell::new();
-            if let Some(value) = self.get() {
-                match res.set(value.clone()) {
-                    Ok(()) => (),
-                    Err(_) => unreachable!(),
-                }
+            match self.get() {
+                Some(value) => Self::with_value(value.clone()),
+                None => Self::new(),
             }
-            res
         }
     }
 
     impl<T> From<T> for OnceCell<T> {
         fn from(value: T) -> Self {
-            let cell = Self::new();
-            cell.get_or_init(|| value);
-            cell
+            Self::with_value(value)
         }
     }
 
@@ -841,6 +836,11 @@ pub mod sync {
         /// Creates a new empty cell.
         pub const fn new() -> OnceCell<T> {
             OnceCell(Imp::new())
+        }
+
+        /// Creates a new initialized cell.
+        pub const fn with_value(value: T) -> OnceCell<T> {
+            OnceCell(Imp::with_value(value))
         }
 
         /// Gets the reference to the underlying value.

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -18,6 +18,13 @@ mod unsync {
     }
 
     #[test]
+    fn once_cell_with_value() {
+        const CELL: OnceCell<i32> = OnceCell::with_value(12);
+        let cell = CELL;
+        assert_eq!(cell.get(), Some(&12));
+    }
+
+    #[test]
     fn once_cell_get_mut() {
         let mut c = OnceCell::new();
         assert!(c.get_mut().is_none());
@@ -228,6 +235,12 @@ mod sync {
         .unwrap();
         c.get_or_init(|| panic!("Kabom!"));
         assert_eq!(c.get(), Some(&92));
+    }
+
+    #[test]
+    fn once_cell_with_value() {
+        static CELL: OnceCell<i32> = OnceCell::with_value(12);
+        assert_eq!(CELL.get(), Some(&12));
     }
 
     #[test]


### PR DESCRIPTION
This PR adds `OnceCell::with_value` to both `sync::OnceCell` and `unsync::OnceCell`. This enables creating an initialized `OnceCell` at compile time and/or without synchronization cost.

Additionally, this improve `Clone` implementations by removing a panicking branch, reducing synchronization cost and overriding `clone_from` implementation.

Closes #164 