### PR TITLE
Explain the atomic orderings used in race

### DIFF
--- a/src/race.rs
+++ b/src/race.rs
@@ -10,13 +10,14 @@
 //!
 //! All types in this module use `Acquire` and `Release`
 //! [atomic orderings](Ordering) for all their operations. While this is not
-//! strictly necessary, it is useful for users as it allows them to be certain
-//! that after `get` or `get_or_init` returns on one thread, any side-effects
-//! caused by the setter thread prior to them calling `set` or `get_or_init`
-//! will be made visible to that thread; without it, it's possible for it to
-//! appear as if they haven't happened yet from the getter thread's perspective.
-//! This is an acceptable tradeoff to make since `Acquire` and `Release` have
-//! very little performance overhead on most architectures versus `Relaxed`.
+//! strictly necessary for types other than `OnceBox`, it is useful for users as
+//! it allows them to be certain that after `get` or `get_or_init` returns on
+//! one thread, any side-effects caused by the setter thread prior to them
+//! calling `set` or `get_or_init` will be made visible to that thread; without
+//! it, it's possible for it to appear as if they haven't happened yet from the
+//! getter thread's perspective. This is an acceptable tradeoff to make since
+//! `Acquire` and `Release` have very little performance overhead on most
+//! architectures versus `Relaxed`.
 
 #[cfg(feature = "atomic-polyfill")]
 use atomic_polyfill as atomic;

--- a/src/race.rs
+++ b/src/race.rs
@@ -5,6 +5,18 @@
 //! them stores the result.
 //!
 //! This module does not require `std` feature.
+//!
+//! # Atomic orderings
+//!
+//! All types in this module use `Acquire` and `Release`
+//! [atomic orderings](Ordering) for all their operations. While this is not
+//! strictly necessary, it is useful for users as it allows them to be certain
+//! that after `get` or `get_or_init` returns on one thread, any side-effects
+//! caused by the setter thread prior to them calling `set` or `get_or_init`
+//! will be made visible to that thread; without it, it's possible for it to
+//! appear as if they haven't happened yet from the getter thread's perspective.
+//! This is an acceptable tradeoff to make since `Acquire` and `Release` have
+//! very little performance overhead on most architectures versus `Relaxed`.
 
 #[cfg(feature = "atomic-polyfill")]
 use atomic_polyfill as atomic;


### PR DESCRIPTION
I believe this is the correct rationale as to why those atomic orderings were chosen in this module. This change also makes it explicit that those orderings are used in the library's public API, better allowing consumers to safely depend on it.