### PR TITLE
Fix comments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,6 +434,15 @@ pub mod unsync {
 
     impl<T> OnceCell<T> {
         /// Creates a new empty cell.
+        ///
+        /// # Example
+        /// ```
+        /// use once_cell::unsync::OnceCell;
+        ///
+        /// let mut cell: OnceCell<u32> = OnceCell::new();
+        /// cell.set(92).unwrap();
+        /// cell = OnceCell::new();
+        /// ```
         pub const fn new() -> OnceCell<T> {
             OnceCell { inner: UnsafeCell::new(None) }
         }
@@ -457,15 +466,7 @@ pub mod unsync {
         ///
         /// This method is allowed to violate the invariant of writing to a `OnceCell`
         /// at most once because it requires `&mut` access to `self`. As with all
-        /// interior mutability, `&mut` access permits arbitrary modification:
-        ///
-        /// ```
-        /// use once_cell::unsync::OnceCell;
-        ///
-        /// let mut cell: OnceCell<u32> = OnceCell::new();
-        /// cell.set(92).unwrap();
-        /// cell = OnceCell::new();
-        /// ```
+        /// interior mutability, `&mut` access permits arbitrary modification.
         pub fn get_mut(&mut self) -> Option<&mut T> {
             // Safe because we have unique access
             unsafe { &mut *self.inner.get() }.as_mut()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,15 +434,6 @@ pub mod unsync {
 
     impl<T> OnceCell<T> {
         /// Creates a new empty cell.
-        ///
-        /// # Example
-        /// ```
-        /// use once_cell::unsync::OnceCell;
-        ///
-        /// let mut cell: OnceCell<u32> = OnceCell::new();
-        /// cell.set(92).unwrap();
-        /// cell = OnceCell::new();
-        /// ```
         pub const fn new() -> OnceCell<T> {
             OnceCell { inner: UnsafeCell::new(None) }
         }
@@ -466,7 +457,16 @@ pub mod unsync {
         ///
         /// This method is allowed to violate the invariant of writing to a `OnceCell`
         /// at most once because it requires `&mut` access to `self`. As with all
-        /// interior mutability, `&mut` access permits arbitrary modification.
+        /// interior mutability, `&mut` access permits arbitrary modification:
+        ///
+        /// ```
+        /// use once_cell::unsync::OnceCell;
+        ///
+        /// let mut cell: OnceCell<u32> = OnceCell::new();
+        /// cell.set(92).unwrap();
+        /// *cell.get_mut().unwrap() = 93;
+        /// assert_eq!(cell.get(), Some(&93));
+        /// ```
         pub fn get_mut(&mut self) -> Option<&mut T> {
             // Safe because we have unique access
             unsafe { &mut *self.inner.get() }.as_mut()


### PR DESCRIPTION
# Fix comments

The example of `get_mut` looks like that for `new`.
Actually,  the comment before the example finishes with ':'. So, it looks like in the middle of sentence or incomplete.