### PR TITLE
Miri detects a deadlock?

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,3 +25,4 @@ jobs:
     - run: cargo run -p xtask -- ci
       env:
         CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        MIRIFLAGS: -Zmiri-disable-weak-memory-emulation


### PR DESCRIPTION
I'm trying to do some hacking locally, and Miri is detecting a deadlock. So I'm putting up this PR just to see if this reproduces in your CI, in which case this is probably related to new Miri behavior.

Yup, deadlock:
```
  error: deadlock: the evaluated program deadlocked
     --> /home/runner/.rustup/toolchains/nightly-2022-06-10-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/unix/futex.rs:69:21
      |
  69  |                     )
      |                     ^ the evaluated program deadlocked
      |
      = note: inside `std::sys::unix::futex::futex_wait` at /home/runner/.rustup/toolchains/nightly-2022-06-10-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/unix/futex.rs:69:21
      = note: inside `std::sys_common::thread_parker::futex::Parker::park` at /home/runner/.rustup/toolchains/nightly-2022-06-10-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys_common/thread_parker/futex.rs:52:13
      = note: inside `std::thread::park` at /home/runner/.rustup/toolchains/nightly-2022-06-10-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:929:9
      = note: inside `std::sync::mpsc::blocking::WaitToken::wait` at /home/runner/.rustup/toolchains/nightly-2022-06-10-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/mpsc/blocking.rs:67:13
      = note: inside `std::sync::mpsc::oneshot::Packet::<()>::recv` at /home/runner/.rustup/toolchains/nightly-2022-06-10-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/mpsc/oneshot.rs:140:21
      = note: inside `std::sync::mpsc::Receiver::<()>::recv` at /home/runner/.rustup/toolchains/nightly-2022-06-10-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/mpsc/mod.rs:1161:49
  note: inside closure at src/imp_std.rs:357:17
     --> src/imp_std.rs:357:17
      |
  357 |                 rx2.recv().unwrap();
      |                 ^^^^^^^^^^
  note: inside closure at src/imp_std.rs:269:54
     --> src/imp_std.rs:269:54
      |
  269 |             let _ = self.initialize(|| Ok::<T, Void>(f()));
      |                                                      ^^^
  note: inside closure at src/imp_std.rs:85:23
     --> src/imp_std.rs:85:23
      |
  85  |                 match f() {
      |                       ^^^
      = note: inside `std::ops::function::impls::<impl std::ops::FnMut<()> for &mut dyn std::ops::FnMut() -> bool>::call_mut` at /home/runner/.rustup/toolchains/nightly-2022-06-10-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:290:13
  note: inside `imp::initialize_or_wait` at src/imp_std.rs:213:20
     --> src/imp_std.rs:213:20
      |
  213 |                 if init() {
      |                    ^^^^^^
  note: inside `imp::OnceCell::<()>::initialize::<[closure@src/imp_std.rs:269:37: 269:58], imp::tests::<impl imp::OnceCell<T>>::init::Void>` at src/imp_std.rs:81:9
     --> src/imp_std.rs:81:9
      |
  81  | /         initialize_or_wait(
  82  | |             &self.queue,
  83  | |             Some(&mut || {
  84  | |                 let f = unsafe { take_unchecked(&mut f) };
  ...   |
  95  | |             }),
  96  | |         );
      | |_________^
  note: inside `imp::tests::<impl imp::OnceCell<()>>::init::<[closure@src/imp_std.rs:355:20: 358:14]>` at src/imp_std.rs:269:21
     --> src/imp_std.rs:269:21
      |
  269 |             let _ = self.initialize(|| Ok::<T, Void>(f()));
      |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  note: inside closure at src/imp_std.rs:355:13
     --> src/imp_std.rs:355:13
      |
  355 | /             O.init(|| {
  356 | |                 tx1.send(()).unwrap();
  357 | |                 rx2.recv().unwrap();
  358 | |             });
      | |______________^
  
  note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
  
  error: aborting due to previous error
  
  error: test failed, to rerun pass '--lib'
  TEST_MIRI: 58.98s
  error: command `cargo miri test --features unstable` failed, exit status: 1
  test imp::tests::wait_for_force_to_finish ... ::endgroup::
```