### PR TITLE
Add `no_std` implementation based on `critical-section`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,13 @@ parking_lot_core = { version = "0.9.3", optional = true, default_features = fals
 atomic-polyfill = { version = "1", optional = true }
 
 # Uses `critical-section` to implement `once_cell::sync::OnceCell`.
-critical-section = { version = "1.1", optional = true }
+critical_section = { package = "critical-section", version = "1.1", optional = true }
 
 [dev-dependencies]
 lazy_static = "1.0.0"
 crossbeam-utils = "0.8.7"
 regex =  "1.2.0"
-critical-section = { version = "1.1", features = ["std"] }
+critical_section = { package = "critical-section", version = "1.1", features = ["std"] }
 
 [features]
 default = ["std"]
@@ -57,7 +57,7 @@ sync = []
 
 parking_lot = ["parking_lot_core"]
 
-critical-section = ["dep:critical-section", "sync"]
+critical-section = ["critical_section", "sync"]
 
 [[example]]
 name = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,3 +89,6 @@ required-features = ["std"]
 
 [package.metadata.docs.rs]
 all-features = true
+
+[patch.crates-io]
+critical-section = { git = "https://github.com/reitermarkus/critical-section", branch = "lock-poisoning" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ critical_section = { package = "critical-section", version = "1.1", optional = t
 lazy_static = "1.0.0"
 crossbeam-utils = "0.8.7"
 regex =  "1.2.0"
-critical_section = { package = "critical-section", version = "1.1", features = ["std"] }
+critical_section = { package = "critical-section", version = "1.1.1", features = ["std"] }
 
 [features]
 default = ["std"]
@@ -89,6 +89,3 @@ required-features = ["std"]
 
 [package.metadata.docs.rs]
 all-features = true
-
-[patch.crates-io]
-critical-section = { git = "https://github.com/reitermarkus/critical-section", branch = "lock-poisoning" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,15 +32,19 @@ parking_lot_core = { version = "0.9.3", optional = true, default_features = fals
 # and make sure you understand all the implications
 atomic-polyfill = { version = "1", optional = true }
 
+# Uses `critical-section` to implement `once_cell::sync::OnceCell`.
+critical-section = { version = "1.1", optional = true }
+
 [dev-dependencies]
 lazy_static = "1.0.0"
 crossbeam-utils = "0.8.7"
 regex =  "1.2.0"
+critical-section = { version = "1.1", features = ["std"] }
 
 [features]
 default = ["std"]
 # Enables `once_cell::sync` module.
-std = ["alloc"]
+std = ["alloc", "sync"]
 # Enables `once_cell::race::OnceBox` type.
 alloc = ["race"]
 # Enables `once_cell::race` module.
@@ -49,7 +53,11 @@ race = []
 # At the moment, this feature is unused.
 unstable = []
 
+sync = []
+
 parking_lot = ["parking_lot_core"]
+
+critical-section = ["dep:critical-section", "sync"]
 
 [[example]]
 name = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ sync = []
 
 parking_lot = ["parking_lot_core"]
 
-critical-section = ["critical_section", "sync"]
+critical-section = ["critical_section", "atomic-polyfill", "sync"]
 
 [[example]]
 name = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ parking_lot_core = { version = "0.9.3", optional = true, default_features = fals
 atomic-polyfill = { version = "1", optional = true }
 
 # Uses `critical-section` to implement `once_cell::sync::OnceCell`.
-critical_section = { package = "critical-section", version = "1.1", optional = true }
+critical_section = { package = "critical-section", version = "1", optional = true }
 
 [dev-dependencies]
 lazy_static = "1.0.0"

--- a/src/imp_cs.rs
+++ b/src/imp_cs.rs
@@ -47,8 +47,6 @@ impl<T> OnceCell<T> {
             let cell = self.value.borrow(cs);
             cell.get_or_try_init(f).map(|_| {
                 self.initialized.store(true, Ordering::Release);
-
-                ()
             })
         })
     }

--- a/src/imp_cs.rs
+++ b/src/imp_cs.rs
@@ -1,22 +1,12 @@
-#[cfg(feature = "atomic-polyfill")]
-use atomic_polyfill as atomic;
-#[cfg(not(feature = "atomic-polyfill"))]
-use core::sync::atomic;
-
-use atomic::{AtomicU8, Ordering};
-
 use core::panic::{RefUnwindSafe, UnwindSafe};
+
+use critical_section::{CriticalSection, Mutex};
 
 use crate::unsync::OnceCell as UnsyncOnceCell;
 
 pub(crate) struct OnceCell<T> {
-    state: AtomicU8,
-    value: UnsyncOnceCell<T>,
+    value: Mutex<UnsyncOnceCell<T>>,
 }
-
-const INCOMPLETE: u8 = 0;
-const RUNNING: u8 = 1;
-const COMPLETE: u8 = 2;
 
 // Why do we need `T: Send`?
 // Thread A creates a `OnceCell` and shares it with
@@ -31,16 +21,18 @@ impl<T: UnwindSafe> UnwindSafe for OnceCell<T> {}
 
 impl<T> OnceCell<T> {
     pub(crate) const fn new() -> OnceCell<T> {
-        OnceCell { state: AtomicU8::new(INCOMPLETE), value: UnsyncOnceCell::new() }
+        OnceCell { value: Mutex::new(UnsyncOnceCell::new()) }
     }
 
     pub(crate) const fn with_value(value: T) -> OnceCell<T> {
-        OnceCell { state: AtomicU8::new(COMPLETE), value: UnsyncOnceCell::with_value(value) }
+        OnceCell { value: Mutex::new(UnsyncOnceCell::with_value(value)) }
     }
 
     #[inline]
     pub(crate) fn is_initialized(&self) -> bool {
-        self.state.load(Ordering::Acquire) == COMPLETE
+        // The only write access is synchronized in `initialize` with a
+        // critical section, so read-only access is valid everywhere else.
+        unsafe { self.value.borrow(CriticalSection::new()).get().is_some() }
     }
 
     #[cold]
@@ -48,30 +40,10 @@ impl<T> OnceCell<T> {
     where
         F: FnOnce() -> Result<T, E>,
     {
-        let mut f = Some(f);
-        let mut res: Result<(), E> = Ok(());
-        let slot: &UnsyncOnceCell<T> = &self.value;
-        initialize_inner(&self.state, &mut || {
-            let f = unsafe { crate::take_unchecked(&mut f) };
-            match f() {
-                Ok(value) => {
-                    unsafe { crate::unwrap_unchecked(slot.set(value).ok()) };
-                    true
-                }
-                Err(err) => {
-                    res = Err(err);
-                    false
-                }
-            }
-        });
-        res
-    }
-
-    #[cold]
-    pub(crate) fn wait(&self) {
-        while !self.is_initialized() {
-            core::hint::spin_loop();
-        }
+        critical_section::with(|cs| {
+            let cell = self.value.borrow(cs);
+            cell.get_or_try_init(f).map(|_| ())
+        })
     }
 
     /// Get the reference to the underlying value, without checking if the cell
@@ -83,49 +55,18 @@ impl<T> OnceCell<T> {
     /// the contents are acquired by (synchronized to) this thread.
     pub(crate) unsafe fn get_unchecked(&self) -> &T {
         debug_assert!(self.is_initialized());
-        self.value.get_unchecked()
+        // The only write access is synchronized in `initialize` with a
+        // critical section, so read-only access is valid everywhere else.
+        self.value.borrow(CriticalSection::new()).get_unchecked()
     }
 
     #[inline]
     pub(crate) fn get_mut(&mut self) -> Option<&mut T> {
-        self.value.get_mut()
+        self.value.get_mut().get_mut()
     }
 
     #[inline]
     pub(crate) fn into_inner(self) -> Option<T> {
-        self.value.into_inner()
-    }
-}
-
-struct Guard<'a> {
-    state: &'a AtomicU8,
-    new_state: u8,
-}
-
-impl<'a> Drop for Guard<'a> {
-    fn drop(&mut self) {
-        self.state.store(self.new_state, Ordering::Release);
-    }
-}
-
-#[inline(never)]
-fn initialize_inner(state: &AtomicU8, init: &mut dyn FnMut() -> bool) {
-    loop {
-        match state.compare_exchange_weak(INCOMPLETE, RUNNING, Ordering::Acquire, Ordering::Acquire)
-        {
-            Ok(_) => {
-                let mut guard = Guard { state, new_state: INCOMPLETE };
-                if init() {
-                    guard.new_state = COMPLETE;
-                }
-                return;
-            }
-            Err(COMPLETE) => return,
-            Err(RUNNING) | Err(INCOMPLETE) => core::hint::spin_loop(),
-            Err(_) => {
-                debug_assert!(false);
-                unsafe { core::hint::unreachable_unchecked() }
-            }
-        }
+        self.value.into_inner().into_inner()
     }
 }

--- a/src/imp_cs.rs
+++ b/src/imp_cs.rs
@@ -1,0 +1,131 @@
+#[cfg(feature = "atomic-polyfill")]
+use atomic_polyfill as atomic;
+#[cfg(not(feature = "atomic-polyfill"))]
+use core::sync::atomic;
+
+use atomic::{AtomicU8, Ordering};
+
+use core::panic::{RefUnwindSafe, UnwindSafe};
+
+use crate::unsync::OnceCell as UnsyncOnceCell;
+
+pub(crate) struct OnceCell<T> {
+    state: AtomicU8,
+    value: UnsyncOnceCell<T>,
+}
+
+const INCOMPLETE: u8 = 0;
+const RUNNING: u8 = 1;
+const COMPLETE: u8 = 2;
+
+// Why do we need `T: Send`?
+// Thread A creates a `OnceCell` and shares it with
+// scoped thread B, which fills the cell, which is
+// then destroyed by A. That is, destructor observes
+// a sent value.
+unsafe impl<T: Sync + Send> Sync for OnceCell<T> {}
+unsafe impl<T: Send> Send for OnceCell<T> {}
+
+impl<T: RefUnwindSafe + UnwindSafe> RefUnwindSafe for OnceCell<T> {}
+impl<T: UnwindSafe> UnwindSafe for OnceCell<T> {}
+
+impl<T> OnceCell<T> {
+    pub(crate) const fn new() -> OnceCell<T> {
+        OnceCell { state: AtomicU8::new(INCOMPLETE), value: UnsyncOnceCell::new() }
+    }
+
+    pub(crate) const fn with_value(value: T) -> OnceCell<T> {
+        OnceCell { state: AtomicU8::new(COMPLETE), value: UnsyncOnceCell::with_value(value) }
+    }
+
+    #[inline]
+    pub(crate) fn is_initialized(&self) -> bool {
+        self.state.load(Ordering::Acquire) == COMPLETE
+    }
+
+    #[cold]
+    pub(crate) fn initialize<F, E>(&self, f: F) -> Result<(), E>
+    where
+        F: FnOnce() -> Result<T, E>,
+    {
+        let mut f = Some(f);
+        let mut res: Result<(), E> = Ok(());
+        let slot: &UnsyncOnceCell<T> = &self.value;
+        initialize_inner(&self.state, &mut || {
+            let f = unsafe { crate::take_unchecked(&mut f) };
+            match f() {
+                Ok(value) => {
+                    unsafe { crate::unwrap_unchecked(slot.set(value).ok()) };
+                    true
+                }
+                Err(err) => {
+                    res = Err(err);
+                    false
+                }
+            }
+        });
+        res
+    }
+
+    #[cold]
+    pub(crate) fn wait(&self) {
+        while !self.is_initialized() {
+            core::hint::spin_loop();
+        }
+    }
+
+    /// Get the reference to the underlying value, without checking if the cell
+    /// is initialized.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that the cell is in initialized state, and that
+    /// the contents are acquired by (synchronized to) this thread.
+    pub(crate) unsafe fn get_unchecked(&self) -> &T {
+        debug_assert!(self.is_initialized());
+        self.value.get_unchecked()
+    }
+
+    #[inline]
+    pub(crate) fn get_mut(&mut self) -> Option<&mut T> {
+        self.value.get_mut()
+    }
+
+    #[inline]
+    pub(crate) fn into_inner(self) -> Option<T> {
+        self.value.into_inner()
+    }
+}
+
+struct Guard<'a> {
+    state: &'a AtomicU8,
+    new_state: u8,
+}
+
+impl<'a> Drop for Guard<'a> {
+    fn drop(&mut self) {
+        self.state.store(self.new_state, Ordering::Release);
+    }
+}
+
+#[inline(never)]
+fn initialize_inner(state: &AtomicU8, init: &mut dyn FnMut() -> bool) {
+    loop {
+        match state.compare_exchange_weak(INCOMPLETE, RUNNING, Ordering::Acquire, Ordering::Acquire)
+        {
+            Ok(_) => {
+                let mut guard = Guard { state, new_state: INCOMPLETE };
+                if init() {
+                    guard.new_state = COMPLETE;
+                }
+                return;
+            }
+            Err(COMPLETE) => return,
+            Err(RUNNING) | Err(INCOMPLETE) => core::hint::spin_loop(),
+            Err(_) => {
+                debug_assert!(false);
+                unsafe { core::hint::unreachable_unchecked() }
+            }
+        }
+    }
+}

--- a/src/imp_pl.rs
+++ b/src/imp_pl.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::UnsafeCell,
-    hint,
     panic::{RefUnwindSafe, UnwindSafe},
     sync::atomic::{AtomicU8, Ordering},
 };
@@ -101,15 +100,8 @@ impl<T> OnceCell<T> {
     /// the contents are acquired by (synchronized to) this thread.
     pub(crate) unsafe fn get_unchecked(&self) -> &T {
         debug_assert!(self.is_initialized());
-        let slot: &Option<T> = &*self.value.get();
-        match slot {
-            Some(value) => value,
-            // This unsafe does improve performance, see `examples/bench`.
-            None => {
-                debug_assert!(false);
-                hint::unreachable_unchecked()
-            }
-        }
+        let slot = &*self.value.get();
+        crate::unwrap_unchecked(slot.as_ref())
     }
 
     /// Gets the mutable reference to the underlying value.

--- a/src/imp_std.rs
+++ b/src/imp_std.rs
@@ -5,14 +5,11 @@
 
 use std::{
     cell::{Cell, UnsafeCell},
-    hint::unreachable_unchecked,
     marker::PhantomData,
     panic::{RefUnwindSafe, UnwindSafe},
     sync::atomic::{AtomicBool, AtomicPtr, Ordering},
     thread::{self, Thread},
 };
-
-use crate::take_unchecked;
 
 #[derive(Debug)]
 pub(crate) struct OnceCell<T> {
@@ -81,7 +78,7 @@ impl<T> OnceCell<T> {
         initialize_or_wait(
             &self.queue,
             Some(&mut || {
-                let f = unsafe { take_unchecked(&mut f) };
+                let f = unsafe { crate::take_unchecked(&mut f) };
                 match f() {
                     Ok(value) => {
                         unsafe { *slot = Some(value) };
@@ -111,15 +108,8 @@ impl<T> OnceCell<T> {
     /// the contents are acquired by (synchronized to) this thread.
     pub(crate) unsafe fn get_unchecked(&self) -> &T {
         debug_assert!(self.is_initialized());
-        let slot: &Option<T> = &*self.value.get();
-        match slot {
-            Some(value) => value,
-            // This unsafe does improve performance, see `examples/bench`.
-            None => {
-                debug_assert!(false);
-                unreachable_unchecked()
-            }
-        }
+        let slot = &*self.value.get();
+        crate::unwrap_unchecked(slot.as_ref())
     }
 
     /// Gets the mutable reference to the underlying value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,11 +336,11 @@ extern crate alloc;
 #[path = "imp_cs.rs"]
 mod imp;
 
-#[cfg(all(feature = "std", feature = "parking_lot", not(feature = "critical-section")))]
+#[cfg(all(feature = "std", feature = "parking_lot"))]
 #[path = "imp_pl.rs"]
 mod imp;
 
-#[cfg(all(feature = "std", not(feature = "parking_lot"), not(feature = "critical-section")))]
+#[cfg(all(feature = "std", not(feature = "parking_lot")))]
 #[path = "imp_std.rs"]
 mod imp;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,11 +329,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
-use core as lib;
-#[cfg(feature = "std")]
-use std as lib;
-
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
@@ -351,12 +346,13 @@ mod imp;
 
 /// Single-threaded version of `OnceCell`.
 pub mod unsync {
-    use super::lib::{
+    use core::{
         cell::{Cell, UnsafeCell},
         fmt, mem,
         ops::{Deref, DerefMut},
         panic::{RefUnwindSafe, UnwindSafe},
     };
+
     use super::unwrap_unchecked;
 
     /// A cell which can be written to only once. It is not thread safe.
@@ -836,15 +832,14 @@ pub mod unsync {
 /// Thread-safe, blocking version of `OnceCell`.
 #[cfg(feature = "sync")]
 pub mod sync {
-    use super::lib::{
+    use core::{
         cell::Cell,
         fmt, mem,
         ops::{Deref, DerefMut},
         panic::RefUnwindSafe,
     };
 
-    use super::imp::OnceCell as Imp;
-    use super::take_unchecked;
+    use super::{imp::OnceCell as Imp, take_unchecked};
 
     /// A thread-safe cell which can be written to only once.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,13 +334,6 @@ use core as lib;
 #[cfg(feature = "std")]
 use std as lib;
 
-use lib::{
-    cell::{Cell, UnsafeCell},
-    fmt, mem,
-    ops::{Deref, DerefMut},
-    panic::{RefUnwindSafe, UnwindSafe},
-};
-
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
@@ -360,7 +353,13 @@ mod imp;
 
 /// Single-threaded version of `OnceCell`.
 pub mod unsync {
-    use super::*;
+    use super::lib::{
+        cell::{Cell, UnsafeCell},
+        fmt, mem,
+        ops::{Deref, DerefMut},
+        panic::{RefUnwindSafe, UnwindSafe},
+    };
+    use super::unwrap_unchecked;
 
     /// A cell which can be written to only once. It is not thread safe.
     ///
@@ -839,9 +838,15 @@ pub mod unsync {
 /// Thread-safe, blocking version of `OnceCell`.
 #[cfg(feature = "sync")]
 pub mod sync {
-    use super::*;
+    use super::lib::{
+        cell::Cell,
+        fmt, mem,
+        ops::{Deref, DerefMut},
+        panic::RefUnwindSafe,
+    };
 
-    use imp::OnceCell as Imp;
+    use super::imp::OnceCell as Imp;
+    use super::take_unchecked;
 
     /// A thread-safe cell which can be written to only once.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -959,6 +959,7 @@ pub mod sync {
         /// assert_eq!(*value, 92);
         /// t.join().unwrap();
         /// ```
+        #[cfg(not(feature = "critical-section"))]
         pub fn wait(&self) -> &T {
             if !self.0.is_initialized() {
                 self.0.wait()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -453,6 +453,7 @@ pub mod unsync {
         /// Gets a reference to the underlying value.
         ///
         /// Returns `None` if the cell is empty.
+        #[inline]
         pub fn get(&self) -> Option<&T> {
             // Safe due to `inner`'s invariant
             unsafe { &*self.inner.get() }.as_ref()
@@ -474,6 +475,7 @@ pub mod unsync {
         /// *cell.get_mut().unwrap() = 93;
         /// assert_eq!(cell.get(), Some(&93));
         /// ```
+        #[inline]
         pub fn get_mut(&mut self) -> Option<&mut T> {
             // Safe because we have unique access
             unsafe { &mut *self.inner.get() }.as_mut()
@@ -486,6 +488,7 @@ pub mod unsync {
         ///
         /// Caller must ensure that the cell is in initialized state.
         #[cfg(feature = "critical-section")]
+        #[inline]
         pub(crate) unsafe fn get_unchecked(&self) -> &T {
             crate::unwrap_unchecked(self.get())
         }
@@ -985,6 +988,7 @@ pub mod sync {
         /// cell.set(92).unwrap();
         /// cell = OnceCell::new();
         /// ```
+        #[inline]
         pub fn get_mut(&mut self) -> Option<&mut T> {
             self.0.get_mut()
         }
@@ -996,6 +1000,7 @@ pub mod sync {
         ///
         /// Caller must ensure that the cell is in initialized state, and that
         /// the contents are acquired by (synchronized to) this thread.
+        #[inline]
         pub unsafe fn get_unchecked(&self) -> &T {
             self.0.get_unchecked()
         }
@@ -1181,6 +1186,7 @@ pub mod sync {
         /// cell.set("hello".to_string()).unwrap();
         /// assert_eq!(cell.into_inner(), Some("hello".to_string()));
         /// ```
+        #[inline]
         pub fn into_inner(self) -> Option<T> {
             self.0.into_inner()
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,17 +337,15 @@ use std as lib;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "critical-section")]
+#[cfg(all(feature = "critical-section", not(feature = "std")))]
 #[path = "imp_cs.rs"]
 mod imp;
 
-#[cfg(all(feature = "std", not(feature = "critical-section")))]
-#[cfg(feature = "parking_lot")]
+#[cfg(all(feature = "std", feature = "parking_lot", not(feature = "critical-section")))]
 #[path = "imp_pl.rs"]
 mod imp;
 
-#[cfg(all(feature = "std", not(feature = "critical-section")))]
-#[cfg(not(feature = "parking_lot"))]
+#[cfg(all(feature = "std", not(feature = "parking_lot"), not(feature = "critical-section")))]
 #[path = "imp_std.rs"]
 mod imp;
 

--- a/src/race.rs
+++ b/src/race.rs
@@ -165,6 +165,7 @@ impl OnceBool {
     fn from_usize(value: NonZeroUsize) -> bool {
         value.get() == 1
     }
+
     #[inline]
     fn to_usize(value: bool) -> NonZeroUsize {
         unsafe { NonZeroUsize::new_unchecked(if value { 1 } else { 2 }) }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -32,6 +32,9 @@ fn main() -> xshell::Result<()> {
         // Skip doctests for no_std tests as those don't work
         cmd!(sh, "cargo test --no-default-features --features unstable --test it").run()?;
         cmd!(sh, "cargo test --no-default-features --features unstable,alloc --test it").run()?;
+
+        cmd!(sh, "cargo test --no-default-features --features critical-section").run()?;
+        cmd!(sh, "cargo test --no-default-features --features critical-section --release").run()?;
     }
 
     {


### PR DESCRIPTION
Add implementation based on `critical-section` for embedded targets.

This started out using `critical_section::Mutex`, but tests were failing since `critical_section::with` blocks all threads during initialization, so I changed it to be basically the same as `imp_pl` without the `parking_lot` parts, since `atomic-polyfill` is based on `critical-section`.

Depends on https://github.com/rust-embedded/critical-section/pull/26.