### PR TITLE
Advertise generic_once_cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ More patterns and use-cases are in the [docs](https://docs.rs/once_cell/)!
 * [lazycell](https://crates.io/crates/lazycell)
 * [mitochondria](https://crates.io/crates/mitochondria)
 * [lazy_static](https://crates.io/crates/lazy_static)
+* [async_once_cell](https://crates.io/crates/async_once_cell)
 
 The API of `once_cell` is being proposed for inclusion in
 [`std`](https://github.com/rust-lang/rfcs/pull/2788).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ More patterns and use-cases are in the [docs](https://docs.rs/once_cell/)!
 * [mitochondria](https://crates.io/crates/mitochondria)
 * [lazy_static](https://crates.io/crates/lazy_static)
 * [async_once_cell](https://crates.io/crates/async_once_cell)
+* [generic_once_cell](https://crates.io/crates/generic_once_cell) (bring your own mutex)
 
 The API of `once_cell` is being proposed for inclusion in
 [`std`](https://github.com/rust-lang/rfcs/pull/2788).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,6 +314,10 @@
 //! **Does this crate support async?**
 //!
 //! No, but you can use [`async_once_cell`](https://crates.io/crates/async_once_cell) instead.
+//! 
+//! **Can I bring my own mutex?**
+//! 
+//! There is [generic_once_cell](https://crates.io/crates/generic_once_cell) to allow just that.
 //!
 //! # Related crates
 //!
@@ -323,6 +327,7 @@
 //! * [mitochondria](https://crates.io/crates/mitochondria)
 //! * [lazy_static](https://crates.io/crates/lazy_static)
 //! * [async_once_cell](https://crates.io/crates/async_once_cell)
+//! * [generic_once_cell](https://crates.io/crates/generic_once_cell) (bring your own mutex)
 //!
 //! Most of this crate's functionality is available in `std` in nightly Rust.
 //! See the [tracking issue](https://github.com/rust-lang/rust/issues/74465).


### PR DESCRIPTION
I just published [generic_once_cell](https://crates.io/crates/generic_once_cell) (docs are still building).

This PR advertises generic_once_cell from the docs and the readme.

Closes https://github.com/matklad/once_cell/issues/207.