### PR TITLE
Fixed `LateInit` recipe stack overflow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,11 +206,8 @@
 //!
 //!
 //! ```
-//! use std::fmt;
-//!
 //! use once_cell::sync::OnceCell;
 //!
-//! #[derive(Debug)]
 //! pub struct LateInit<T> { cell: OnceCell<T> }
 //!
 //! impl<T> LateInit<T> {
@@ -240,24 +237,14 @@
 //!     a: LateInit<&'a A<'a>>
 //! }
 //!
-//! impl fmt::Debug for A<'_> {
-//!     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-//!         write!(f, "A")
-//!     }
-//! }
-//!
-//! impl fmt::Debug for B<'_> {
-//!     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-//!         write!(f, "B")
-//!     }
-//! }
 //!
 //! fn build_cycle() {
 //!     let a = A::default();
 //!     let b = B::default();
 //!     a.b.init(&b);
 //!     b.a.init(&a);
-//!     println!("{:?}", a.b.a.b.a);
+//!     
+//!     let _a = &a.b.a.b.a;
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,8 @@
 //!
 //!
 //! ```
+//! use std::fmt;
+//!
 //! use once_cell::sync::OnceCell;
 //!
 //! #[derive(Debug)]
@@ -228,14 +230,26 @@
 //!     }
 //! }
 //!
-//! #[derive(Default, Debug)]
+//! #[derive(Default)]
 //! struct A<'a> {
 //!     b: LateInit<&'a B<'a>>,
 //! }
 //!
-//! #[derive(Default, Debug)]
+//! #[derive(Default)]
 //! struct B<'a> {
 //!     a: LateInit<&'a A<'a>>
+//! }
+//!
+//! impl fmt::Debug for A<'_> {
+//!     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//!         write!(f, "A")
+//!     }
+//! }
+//!
+//! impl fmt::Debug for B<'_> {
+//!     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//!         write!(f, "B")
+//!     }
 //! }
 //!
 //! fn build_cycle() {
@@ -314,9 +328,9 @@
 //! **Does this crate support async?**
 //!
 //! No, but you can use [`async_once_cell`](https://crates.io/crates/async_once_cell) instead.
-//! 
+//!
 //! **Can I bring my own mutex?**
-//! 
+//!
 //! There is [generic_once_cell](https://crates.io/crates/generic_once_cell) to allow just that.
 //!
 //! # Related crates


### PR DESCRIPTION
The given `LateInit` recipe works up until the print statement, which causes a stack overflow as the derived `Debug` implementation tries to write out:
```rs
LateInit { cell: OnceCell(A { b: LateInit { cell: OnceCell(B { a: LateInit // repeats endlessly from here
```
To fix this, I've added in a rudimentary `Debug` impl.