### PR TITLE
Add once_cell::race::OnceRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 -
 
+## 1.17.0
+
+- Add `race::OnceRef` for storing a `&'a T`.
+
 ## 1.16.0
 
 - Add `no_std` implementation based on `critical-section`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Like OnceBox, but stores a shared reference instead of a Box.

Mainly useful for `#![no_std]` environments where we can use it to store a `&'static T`.