### PR TITLE
AcqRel -> Release for compare_exchange success ordering in race module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 -
 
+## 1.17.1
+
+- Make `OnceRef` implementation compliant with [strict provenance](https://github.com/rust-lang/rust/issues/95228).
+- Weaken `compare_exchange` success case ordering in `race::*` implementations
+  from `AcqRel` to `Release`, [#xxx](https://github.com/matklad/once_cell/pull/xxx)
+
 ## 1.17.0
 
 - Add `race::OnceRef` for storing a `&'a T`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/src/race.rs
+++ b/src/race.rs
@@ -57,7 +57,7 @@ impl OnceNonZeroUsize {
     #[inline]
     pub fn set(&self, value: NonZeroUsize) -> Result<(), ()> {
         let exchange =
-            self.inner.compare_exchange(0, value.get(), Ordering::AcqRel, Ordering::Acquire);
+            self.inner.compare_exchange(0, value.get(), Ordering::Release, Ordering::Acquire);
         match exchange {
             Ok(_) => Ok(()),
             Err(_) => Err(()),
@@ -98,7 +98,7 @@ impl OnceNonZeroUsize {
             None => {
                 let mut val = f()?.get();
                 let exchange =
-                    self.inner.compare_exchange(0, val, Ordering::AcqRel, Ordering::Acquire);
+                    self.inner.compare_exchange(0, val, Ordering::Release, Ordering::Acquire);
                 if let Err(old) = exchange {
                     val = old;
                 }
@@ -215,7 +215,7 @@ impl<'a, T> OnceRef<'a, T> {
     pub fn set(&self, value: &'a T) -> Result<(), ()> {
         let ptr = value as *const T as *mut T;
         let exchange =
-            self.inner.compare_exchange(ptr::null_mut(), ptr, Ordering::AcqRel, Ordering::Acquire);
+            self.inner.compare_exchange(ptr::null_mut(), ptr, Ordering::Release, Ordering::Acquire);
         match exchange {
             Ok(_) => Ok(()),
             Err(_) => Err(()),
@@ -258,7 +258,7 @@ impl<'a, T> OnceRef<'a, T> {
             let exchange = self.inner.compare_exchange(
                 ptr::null_mut(),
                 ptr,
-                Ordering::AcqRel,
+                Ordering::Release,
                 Ordering::Acquire,
             );
             if let Err(old) = exchange {
@@ -348,7 +348,7 @@ mod once_box {
             let exchange = self.inner.compare_exchange(
                 ptr::null_mut(),
                 ptr,
-                Ordering::AcqRel,
+                Ordering::Release,
                 Ordering::Acquire,
             );
             if let Err(_) = exchange {
@@ -394,7 +394,7 @@ mod once_box {
                 let exchange = self.inner.compare_exchange(
                     ptr::null_mut(),
                     ptr,
-                    Ordering::AcqRel,
+                    Ordering::Release,
                     Ordering::Acquire,
                 );
                 if let Err(old) = exchange {


### PR DESCRIPTION
Implements change discussed in #220