### PR TITLE
Proof of Concept: making `Lazy<T, F>` covariant in `F`

### DIFF
--- a/src/covariant_cell_option.rs
+++ b/src/covariant_cell_option.rs
@@ -1,0 +1,59 @@
+//! A `Cell<Option<F>>`, but covariant, at the cost of a very reduced API.
+//!
+//! (the idea being: it starts as `Some(F)`, and the only `&`-based operation
+//! is `take()`ing it. This guarantees covariance to be fine, since the `F`
+//! value is never overwritten).
+
+use ::core::{cell::Cell, mem::ManuallyDrop};
+
+pub struct CovariantCellOption<F> {
+    /// Invariant: if this is `true` then `value` must contain a non-dropped `F`;
+    is_some: Cell<bool>,
+    value: ManuallyDrop<F>,
+}
+
+impl<F> CovariantCellOption<F> {
+    pub const fn some(value: F) -> Self {
+        Self { is_some: Cell::new(true), value: ManuallyDrop::new(value) }
+    }
+
+    pub fn into_inner(self) -> Option<F> {
+        // Small optimization: disable drop glue so as not to have to overwrite `is_some`.
+        let mut this = ManuallyDrop::new(self);
+        let is_some = this.is_some.get_mut();
+        is_some.then(|| unsafe {
+            // SAFETY: as per the invariant, we can use `value`. We can also *consume* it by doing:
+            // *is_some = false;
+            // but we actually don't even need to do it since we don't use `this` anymore.
+            ManuallyDrop::take(&mut this.value)
+        })
+    }
+
+    pub fn take(&self) -> Option<F> {
+        self.is_some.get().then(|| unsafe {
+            // SAFETY: as per the invariant, we can use `value`.
+            // Clearing the `is_some` flag also lets us *consume* it.
+            self.is_some.set(false);
+            // `ManuallyDrop::take_by_ref`, morally.
+            <*const F>::read(&*self.value)
+        })
+    }
+}
+
+impl<F> Drop for CovariantCellOption<F> {
+    fn drop(&mut self) {
+        if *self.is_some.get_mut() {
+            unsafe {
+                // SAFETY: as per the invariant, we can use `value`.
+                ManuallyDrop::drop(&mut self.value)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+fn _assert_covariance<'short>(
+    long: *const (CovariantCellOption<&'static ()>,),
+) -> *const (CovariantCellOption<&'short ()>,) {
+    long
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -757,7 +757,8 @@ pub mod unsync {
             let cell = this.cell;
             let init = this.init;
             cell.into_inner().ok_or_else(|| {
-                init.take().unwrap_or_else(|| panic!("Lazy instance has previously been poisoned"))
+                init.into_inner()
+                    .unwrap_or_else(|| panic!("Lazy instance has previously been poisoned"))
             })
         }
     }
@@ -1288,7 +1289,8 @@ pub mod sync {
             let cell = this.cell;
             let init = this.init;
             cell.into_inner().ok_or_else(|| {
-                init.take().unwrap_or_else(|| panic!("Lazy instance has previously been poisoned"))
+                init.into_inner()
+                    .unwrap_or_else(|| panic!("Lazy instance has previously been poisoned"))
             })
         }
     }

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -1,7 +1,16 @@
 /// Put here any code relying on duck-typed `Lazy` and `OnceCell`, oblivious to
 /// their exact `sync` or `unsync` nature.
 macro_rules! tests_for_both {() => (
-    /* TODO */
+    /// <https://github.com/matklad/once_cell/issues/167>
+    #[test]
+    fn assert_lazy_is_covariant_in_the_ctor() {
+        #[allow(dead_code)]
+        type AnyLazy<'f, T> = Lazy<T, Box<dyn 'f + FnOnce() -> T>>;
+
+        fn _for<'short, T>(it: *const (AnyLazy<'static, T>, )) -> *const (AnyLazy<'short, T>, ) {
+            it
+        }
+    }
 )}
 
 mod unsync {

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -1,3 +1,9 @@
+/// Put here any code relying on duck-typed `Lazy` and `OnceCell`, oblivious to
+/// their exact `sync` or `unsync` nature.
+macro_rules! tests_for_both {() => (
+    /* TODO */
+)}
+
 mod unsync {
     use core::{
         cell::Cell,
@@ -5,6 +11,8 @@ mod unsync {
     };
 
     use once_cell::unsync::{Lazy, OnceCell};
+
+    tests_for_both!();
 
     #[test]
     fn once_cell() {
@@ -262,6 +270,8 @@ mod sync {
     use crossbeam_utils::thread::scope;
 
     use once_cell::sync::{Lazy, OnceCell};
+
+    tests_for_both!();
 
     #[test]
     fn once_cell() {


### PR DESCRIPTION
Proof of Concept of my idea from https://github.com/matklad/once_cell/issues/167#issuecomment-1564727077

  - `CovariantCellOption<F>` is soundly covariant since the `F` value is never overwritten.

If this PoC were to be merged, it would fix https://github.com/matklad/once_cell/issues/167.

Although it does so at the cost of loss of discriminant elision of `Option<F>`, which means it makes `Lazy`s bigger. This could be deemed too high a cost for a somewhat niche feature.

  - an alternative could be to offer a `LazyCovariantCtor<T, F>` type which would thereby let users pick their preferred flavor.