### PR TITLE
Avoid unnecessary synchronization in `{force,deref}_mut`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 -
 
+## 1.17.2
+
+- Avoid unnecessary synchronization in `Lazy::{force,deref}_mut()`, [#231](https://github.com/matklad/once_cell/pull/231).
+
 ## 1.17.1
 
 - Make `OnceRef` implementation compliant with [strict provenance](https://github.com/rust-lang/rust/issues/95228).

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -45,7 +45,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
- "once_cell 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.14.0",
 ]
 
 [[package]]
@@ -69,19 +69,20 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 [[package]]
 name = "once_cell"
 version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+
+[[package]]
+name = "once_cell"
+version = "1.17.2"
 dependencies = [
  "atomic-polyfill",
+ "critical-section",
  "crossbeam-utils",
  "lazy_static",
  "parking_lot_core",
  "regex",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "parking_lot_core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.2"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
  - `DerefMut` was not delegating to `force_mut()` (contary to the by-ref APIs);
  - `Lazy::force_mut` was not taking advantage of exclusive-mutability access, and instead paying shared-mutability access. Mainly, in the `sync` case, it involved atomic operations which are now skipped.

Fixes #226