### PR TITLE
Make `unsync::Lazy<T, F>` covariant in `F`

### DIFF
--- a/tests/it.rs
+++ b/tests/it.rs
@@ -299,6 +299,16 @@ mod unsync {
             cell.set(&s).unwrap();
         }
     }
+
+    #[test]
+    fn assert_lazy_is_covariant_in_the_ctor() {
+        #[allow(dead_code)]
+        type AnyLazy<'f, T> = Lazy<T, Box<dyn 'f + FnOnce() -> T>>;
+
+        fn _for<'short, T>(it: *const (AnyLazy<'static, T>,)) -> *const (AnyLazy<'short, T>,) {
+            it
+        }
+    }
 }
 
 #[cfg(any(feature = "std", feature = "critical-section"))]

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -2,7 +2,49 @@
 /// their exact `sync` or `unsync` nature.
 macro_rules! tests_for_both {
     () => {
-        /* TODO */
+        #[test]
+        fn lazy_does_drop() {
+            type Counter = std::rc::Rc<()>;
+
+            let (counter, [c1, c2, c3]) = {
+                let c = Counter::new(());
+                (Counter::downgrade(&c), [(); 3].map(|()| c.clone()))
+            };
+            assert_eq!(counter.strong_count(), 3);
+
+            let lazy_1 = Lazy::<Counter, _>::new(|| c1);
+            assert_eq!(counter.strong_count(), 3);
+            drop(lazy_1);
+            assert_eq!(
+                counter.strong_count(),
+                2,
+                "dropping a `Lazy::Uninit` drops the `init` closure"
+            );
+
+            let lazy_2 = Lazy::<Counter, _>::new(|| c2);
+            Lazy::force(&lazy_2);
+            assert_eq!(
+                counter.strong_count(),
+                2,
+                "from `Lazy::Uninit` to `Lazy::Value` drops `init` but owns `value`"
+            );
+            drop(lazy_2);
+            assert_eq!(counter.strong_count(), 1, "dropping a `Lazy::Value` drops its `value`");
+
+            let lazy_3 = Lazy::<Counter, _>::new(|| {
+                None::<()>.unwrap();
+                c3
+            });
+            assert_eq!(counter.strong_count(), 1);
+            let _ = std::panic::catch_unwind(|| Lazy::force(&lazy_3)).expect_err("it panicked");
+            assert_eq!(
+                counter.strong_count(),
+                0,
+                "`init` closure is properly dropped despite panicking"
+            );
+            drop(lazy_3);
+            assert_eq!(counter.strong_count(), 0, "what is dead may never die 🧟");
+        }
     };
 }
 

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -1,3 +1,11 @@
+/// Put here any code relying on duck-typed `Lazy` and `OnceCell`, oblivious to
+/// their exact `sync` or `unsync` nature.
+macro_rules! tests_for_both {
+    () => {
+        /* TODO */
+    };
+}
+
 mod unsync {
     use core::{
         cell::Cell,
@@ -5,6 +13,8 @@ mod unsync {
     };
 
     use once_cell::unsync::{Lazy, OnceCell};
+
+    tests_for_both!();
 
     #[test]
     fn once_cell() {
@@ -262,6 +272,8 @@ mod sync {
     use crossbeam_utils::thread::scope;
 
     use once_cell::sync::{Lazy, OnceCell};
+
+    tests_for_both!();
 
     #[test]
     fn once_cell() {


### PR DESCRIPTION
"Continuation" from https://github.com/matklad/once_cell/pull/230, which partially handles https://github.com/matklad/once_cell/issues/167.

  - Incidentally, this also makes `unsync::Lazy` smaller in size in most cases, since `T` and `F` are now sharing the same `union` storage.

The `sync` can basically use the same logic (my PR paves the way for such a follow-up PR), only the whole thing would need to be moved to each of the possible `imp`lementations of `sync::OnceCell`, and special care to synchronization semantics will be in order, which I prefer to let somebody else do.