### PR TITLE
Remove `PhantomData<*mut Waiter>` so we don't need to manually `impl Send`

### DIFF
--- a/src/imp_std.rs
+++ b/src/imp_std.rs
@@ -5,7 +5,6 @@
 
 use std::{
     cell::{Cell, UnsafeCell},
-    marker::PhantomData,
     panic::{RefUnwindSafe, UnwindSafe},
     sync::atomic::{AtomicBool, AtomicPtr, Ordering},
     thread::{self, Thread},
@@ -22,7 +21,6 @@ pub(crate) struct OnceCell<T> {
     // State is encoded in two low bits. Only `INCOMPLETE` and `RUNNING` states
     // allow waiters.
     queue: AtomicPtr<Waiter>,
-    _marker: PhantomData<*mut Waiter>,
     value: UnsafeCell<Option<T>>,
 }
 
@@ -32,7 +30,6 @@ pub(crate) struct OnceCell<T> {
 // then destroyed by A. That is, destructor observes
 // a sent value.
 unsafe impl<T: Sync + Send> Sync for OnceCell<T> {}
-unsafe impl<T: Send> Send for OnceCell<T> {}
 
 impl<T: RefUnwindSafe + UnwindSafe> RefUnwindSafe for OnceCell<T> {}
 impl<T: UnwindSafe> UnwindSafe for OnceCell<T> {}
@@ -41,7 +38,6 @@ impl<T> OnceCell<T> {
     pub(crate) const fn new() -> OnceCell<T> {
         OnceCell {
             queue: AtomicPtr::new(INCOMPLETE_PTR),
-            _marker: PhantomData,
             value: UnsafeCell::new(None),
         }
     }
@@ -49,7 +45,6 @@ impl<T> OnceCell<T> {
     pub(crate) const fn with_value(value: T) -> OnceCell<T> {
         OnceCell {
             queue: AtomicPtr::new(COMPLETE_PTR),
-            _marker: PhantomData,
             value: UnsafeCell::new(Some(value)),
         }
     }


### PR DESCRIPTION
The effect of having `PhantomData<*mut Waiter>` is that the `OnceCell<T>` stops being `impl<T: Send> Send for OnceCell<T>`. But we want it to be `impl<T: Send> Send for OnceCell<T>`, because we manually mark it as such.

By removing the `PhantomData` we can also remove the manual `impl Send`. The net effect is zero changes to the public API surface (including auto traits) of `once_cell`:

```
$ cargo install cargo-public-api --locked
$ cargo public-api diff origin/master..remove-unneeded-phantomdata
Removed items from the public API
=================================
(none)

Changed items in the public API
===============================
(none)

Added items to the public API
=============================
(none)
```

A variant of this PR is to remove the `PhantomData` but keep the manual `impl Send`. Maybe you prefer the explicitness.

# Background of this PR

I am studying how `once_cell` is implemented, and could not at first understand why we needed the `PhantomData<*mut Waiter>`. Digging deeper, I concluded that we do not in fact need it.