### PR TITLE
Support slices in `OnceRef` and `OnceBox`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.18.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 description = "Single assignment cells and lazy values."
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.18.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.61"
 
 description = "Single assignment cells and lazy values."
 readme = "README.md"

--- a/src/race.rs
+++ b/src/race.rs
@@ -21,6 +21,7 @@
 
 #[cfg(feature = "critical-section")]
 use atomic_polyfill as atomic;
+use core::ptr::NonNull;
 #[cfg(not(feature = "critical-section"))]
 use core::sync::atomic;
 
@@ -28,7 +29,7 @@ use atomic::{AtomicPtr, AtomicUsize, Ordering};
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
 use core::num::NonZeroUsize;
-use core::ptr;
+use core::{mem, ptr};
 
 /// A thread-safe cell which can be written to only once.
 #[derive(Default, Debug)]
@@ -175,51 +176,275 @@ impl OnceBool {
     }
 }
 
+/// Public-in-private items to support `T: Sized` and `[T]` for `OnceRef` and
+/// `OnceBox`.
+mod once_ptr {
+    use super::*;
+
+    /// Common implementation for `OnceRef` and `OnceBox`.
+    pub struct OncePtrInner<T: ?Sized> {
+        /// Stores either:
+        /// - `AtomicPtr<T>` if `T: Sized`
+        /// - `(AtomicPtr<T>, AtomicUsize)` if `[T]`
+        pub ptr: UnsafeCell<*mut T>,
+    }
+
+    // SAFETY: This is semantically used like an `AtomicPtr<T>`.
+    unsafe impl<T: ?Sized> Send for OncePtrInner<T> {}
+    unsafe impl<T: ?Sized> Sync for OncePtrInner<T> {}
+
+    pub trait OncePointee {
+        /// The default uninitialized state.
+        const UNINIT: *mut Self;
+
+        fn get(once: &OncePtrInner<Self>) -> *mut Self;
+
+        fn set(once: &OncePtrInner<Self>, new: NonNull<Self>) -> Result<(), ()>;
+
+        fn get_or_try_init<F, E>(once: &OncePtrInner<Self>, f: F) -> Result<NonNull<Self>, E>
+        where
+            F: FnOnce() -> Result<NonNull<Self>, E>;
+    }
+}
+
+use once_ptr::*;
+
+impl<T> OncePointee for T {
+    const UNINIT: *mut Self = ptr::null_mut();
+
+    fn get(once: &OncePtrInner<Self>) -> *mut Self {
+        once.atomic_ptr().load(Ordering::Acquire)
+    }
+
+    fn set(once: &OncePtrInner<Self>, new: NonNull<Self>) -> Result<(), ()> {
+        let ptr = new.as_ptr();
+
+        let exchange = once.atomic_ptr().compare_exchange(
+            ptr::null_mut(),
+            ptr,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+
+        match exchange {
+            Ok(_) => Ok(()),
+            Err(_) => Err(()),
+        }
+    }
+
+    fn get_or_try_init<F, E>(once: &OncePtrInner<Self>, f: F) -> Result<NonNull<Self>, E>
+    where
+        F: FnOnce() -> Result<NonNull<Self>, E>,
+    {
+        let once_ptr = once.atomic_ptr();
+        let mut ptr = once_ptr.load(Ordering::Acquire);
+
+        if ptr.is_null() {
+            ptr = f()?.as_ptr();
+
+            let exchange = once_ptr.compare_exchange(
+                ptr::null_mut(),
+                ptr,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            );
+
+            if let Err(old) = exchange {
+                ptr = old;
+            }
+        }
+
+        Ok(unsafe { NonNull::new_unchecked(ptr) })
+    }
+}
+
+impl<T> OncePointee for [T] {
+    // An uninitialized slice pointer has both a null address and invalid
+    // length. This enables us to initialize the parts in two separate
+    // operations while ensuring that concurrent readers can determine whether
+    // the slice is fully initialized.
+    //
+    // TODO: Use `slice_from_raw_parts_mut` once stable in `const`.
+    const UNINIT: *mut Self = ptr::slice_from_raw_parts(ptr::null::<T>(), usize::MAX) as _;
+
+    fn get(once: &OncePtrInner<Self>) -> *mut Self {
+        let (once_ptr, once_len) = once.atomic_parts();
+
+        let mut ptr = ptr::null_mut();
+
+        let len = once_len.load(Ordering::Acquire);
+        let len_is_init = (len as isize) >= 0;
+
+        // The pointer is not initialized until after the length is.
+        if len_is_init {
+            ptr = once_ptr.load(Ordering::Acquire);
+        }
+
+        ptr::slice_from_raw_parts_mut(ptr, len)
+    }
+
+    fn set(once: &OncePtrInner<Self>, new: NonNull<Self>) -> Result<(), ()> {
+        let new_ptr = new.as_ptr() as *mut T;
+        let new_len = new.len();
+
+        let (once_ptr, once_len) = once.atomic_parts();
+
+        let exchange =
+            once_len.compare_exchange(usize::MAX, new_len, Ordering::AcqRel, Ordering::Acquire);
+
+        match exchange {
+            Ok(_) => {
+                // We initialized our length first, so store our pointer.
+                once_ptr.store(new_ptr, Ordering::Release);
+                Ok(())
+            }
+            Err(_) => Err(()),
+        }
+    }
+
+    fn get_or_try_init<F, E>(once: &OncePtrInner<Self>, f: F) -> Result<NonNull<Self>, E>
+    where
+        F: FnOnce() -> Result<NonNull<Self>, E>,
+    {
+        let (once_ptr, once_len) = once.atomic_parts();
+
+        let mut ptr = once_ptr.load(Ordering::Acquire);
+        let mut len;
+
+        if ptr.is_null() {
+            let slice_ptr = f()?;
+            ptr = slice_ptr.as_ptr() as *mut T;
+            len = slice_ptr.len();
+
+            // Attempt to initialize our length.
+            let exchange =
+                once_len.compare_exchange(usize::MAX, len, Ordering::AcqRel, Ordering::Acquire);
+
+            match exchange {
+                Ok(_) => {
+                    // We initialized our length first, so store our pointer.
+                    once_ptr.store(ptr, Ordering::Release);
+                }
+                Err(real_len) => {
+                    len = real_len;
+
+                    // Spin briefly until the other thread initializes the
+                    // pointer.
+                    ptr = loop {
+                        let real_ptr = once_ptr.load(Ordering::Acquire);
+                        if real_ptr.is_null() {
+                            core::hint::spin_loop();
+                        } else {
+                            break real_ptr;
+                        }
+                    }
+                }
+            }
+        } else {
+            // The pointer is not initialized until after the length is, so we
+            // can assume a valid slice.
+            len = once_len.load(Ordering::Acquire);
+        }
+
+        Ok(unsafe { NonNull::new_unchecked(ptr::slice_from_raw_parts_mut(ptr, len)) })
+    }
+}
+
+impl<T: ?Sized + OncePointee> OncePtrInner<T> {
+    const fn new() -> Self {
+        Self { ptr: UnsafeCell::new(T::UNINIT) }
+    }
+}
+
+impl<T> OncePtrInner<T> {
+    /// Retrieves the underlying `AtomicPtr`.
+    fn atomic_ptr(&self) -> &AtomicPtr<T> {
+        // SAFETY: `AtomicPtr<T>` is guaranteed to have the same in-memory
+        // representation as `*mut T`.
+        unsafe { &*(self.ptr.get() as *const AtomicPtr<T>) }
+    }
+}
+
+impl<T> OncePtrInner<[T]> {
+    /// `true` if the `*const [T]` address comes before the length.
+    const IS_PTR_FIRST: bool = {
+        let ptr = ptr::null::<T>();
+        let len = usize::MAX;
+        let slice: *const [T] = ptr::slice_from_raw_parts(ptr, len);
+
+        // SAFETY: Both types have the same memory layout.
+        let parts: [usize; 2] = unsafe { mem::transmute(slice) };
+
+        parts[0] != len
+    };
+
+    /// Retrieves the underlying `AtomicPtr` and `AtomicUsize`.
+    fn atomic_parts(&self) -> (&AtomicPtr<T>, &AtomicUsize) {
+        // SAFETY: `IS_PTR_FIRST` guarantees that the address and length of a
+        // `*mut [T]` are where we expect them to be. Also, `AtomicPtr<T>` and
+        // `AtomicUsize` are guaranteed to have the same in-memory
+        // representation as `*mut T` and `usize` respectively.
+        unsafe {
+            let start = self.ptr.get();
+
+            let (ptr, len) = if Self::IS_PTR_FIRST {
+                let ptr = start as *const AtomicPtr<T>;
+                (ptr, ptr.add(1) as *const AtomicUsize)
+            } else {
+                let len = start as *const AtomicUsize;
+                (len.add(1) as *const AtomicPtr<T>, len)
+            };
+
+            (&*ptr, &*len)
+        }
+    }
+}
+
 /// A thread-safe cell which can be written to only once.
-pub struct OnceRef<'a, T> {
-    inner: AtomicPtr<T>,
+pub struct OnceRef<'a, T: ?Sized> {
+    inner: OncePtrInner<T>,
     ghost: PhantomData<UnsafeCell<&'a T>>,
 }
 
 // TODO: Replace UnsafeCell with SyncUnsafeCell once stabilized
-unsafe impl<'a, T: Sync> Sync for OnceRef<'a, T> {}
+unsafe impl<'a, T: ?Sized + Sync> Sync for OnceRef<'a, T> {}
 
 impl<'a, T> core::fmt::Debug for OnceRef<'a, T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "OnceRef({:?})", self.inner)
+        write!(f, "OnceRef({:?})", self.inner.atomic_ptr())
     }
 }
 
-impl<'a, T> Default for OnceRef<'a, T> {
+impl<'a, T> core::fmt::Debug for OnceRef<'a, [T]> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let (ptr, _) = self.inner.atomic_parts();
+        write!(f, "OnceRef({:?})", ptr)
+    }
+}
+
+impl<'a, T: ?Sized + OncePointee> Default for OnceRef<'a, T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'a, T> OnceRef<'a, T> {
+impl<'a, T: ?Sized + OncePointee> OnceRef<'a, T> {
     /// Creates a new empty cell.
     pub const fn new() -> OnceRef<'a, T> {
-        OnceRef { inner: AtomicPtr::new(ptr::null_mut()), ghost: PhantomData }
+        OnceRef { inner: OncePtrInner::new(), ghost: PhantomData }
     }
 
     /// Gets a reference to the underlying value.
     pub fn get(&self) -> Option<&'a T> {
-        let ptr = self.inner.load(Ordering::Acquire);
+        let ptr = <T as OncePointee>::get(&self.inner);
         unsafe { ptr.as_ref() }
     }
 
     /// Sets the contents of this cell to `value`.
     ///
-    /// Returns `Ok(())` if the cell was empty and `Err(value)` if it was
-    /// full.
+    /// Returns `Ok(())` if the cell was empty and `Err(())` if it was full.
     pub fn set(&self, value: &'a T) -> Result<(), ()> {
-        let ptr = value as *const T as *mut T;
-        let exchange =
-            self.inner.compare_exchange(ptr::null_mut(), ptr, Ordering::AcqRel, Ordering::Acquire);
-        match exchange {
-            Ok(_) => Ok(()),
-            Err(_) => Err(()),
-        }
+        <T as OncePointee>::set(&self.inner, NonNull::from(value))
     }
 
     /// Gets the contents of the cell, initializing it with `f` if the cell was
@@ -250,23 +475,8 @@ impl<'a, T> OnceRef<'a, T> {
     where
         F: FnOnce() -> Result<&'a T, E>,
     {
-        let mut ptr = self.inner.load(Ordering::Acquire);
-
-        if ptr.is_null() {
-            // TODO replace with `cast_mut` when MSRV reaches 1.65.0 (also in `set`)
-            ptr = f()? as *const T as *mut T;
-            let exchange = self.inner.compare_exchange(
-                ptr::null_mut(),
-                ptr,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            );
-            if let Err(old) = exchange {
-                ptr = old;
-            }
-        }
-
-        Ok(unsafe { &*ptr })
+        <T as OncePointee>::get_or_try_init(&self.inner, || f().map(NonNull::from))
+            .map(|ptr| unsafe { ptr.as_ref() })
     }
 
     /// ```compile_fail
@@ -292,51 +502,57 @@ pub use self::once_box::OnceBox;
 
 #[cfg(feature = "alloc")]
 mod once_box {
-    use super::atomic::{AtomicPtr, Ordering};
-    use core::{marker::PhantomData, ptr};
+    use core::{marker::PhantomData, ptr::NonNull};
 
     use alloc::boxed::Box;
 
+    use super::{OncePointee, OncePtrInner};
+
     /// A thread-safe cell which can be written to only once.
-    pub struct OnceBox<T> {
-        inner: AtomicPtr<T>,
+    pub struct OnceBox<T: ?Sized> {
+        inner: OncePtrInner<T>,
         ghost: PhantomData<Option<Box<T>>>,
     }
 
     impl<T> core::fmt::Debug for OnceBox<T> {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            write!(f, "OnceBox({:?})", self.inner.load(Ordering::Relaxed))
+            write!(f, "OnceBox({:?})", self.inner.atomic_ptr())
         }
     }
 
-    impl<T> Default for OnceBox<T> {
+    impl<T> core::fmt::Debug for OnceBox<[T]> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            let (ptr, _) = self.inner.atomic_parts();
+            write!(f, "OnceBox({:?})", ptr)
+        }
+    }
+
+    impl<T: ?Sized + OncePointee> Default for OnceBox<T> {
         fn default() -> Self {
             Self::new()
         }
     }
 
-    impl<T> Drop for OnceBox<T> {
+    impl<T: ?Sized> Drop for OnceBox<T> {
         fn drop(&mut self) {
-            let ptr = *self.inner.get_mut();
+            let ptr = *self.inner.ptr.get_mut();
             if !ptr.is_null() {
+                // SAFETY: `&mut self` guarantees exclusive access to `ptr`.
                 drop(unsafe { Box::from_raw(ptr) })
             }
         }
     }
 
-    impl<T> OnceBox<T> {
+    impl<T: ?Sized + OncePointee> OnceBox<T> {
         /// Creates a new empty cell.
         pub const fn new() -> OnceBox<T> {
-            OnceBox { inner: AtomicPtr::new(ptr::null_mut()), ghost: PhantomData }
+            OnceBox { inner: OncePtrInner::new(), ghost: PhantomData }
         }
 
         /// Gets a reference to the underlying value.
         pub fn get(&self) -> Option<&T> {
-            let ptr = self.inner.load(Ordering::Acquire);
-            if ptr.is_null() {
-                return None;
-            }
-            Some(unsafe { &*ptr })
+            let ptr = <T as OncePointee>::get(&self.inner);
+            unsafe { ptr.as_ref() }
         }
 
         /// Sets the contents of this cell to `value`.
@@ -345,16 +561,15 @@ mod once_box {
         /// full.
         pub fn set(&self, value: Box<T>) -> Result<(), Box<T>> {
             let ptr = Box::into_raw(value);
-            let exchange = self.inner.compare_exchange(
-                ptr::null_mut(),
-                ptr,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            );
-            if exchange.is_err() {
+
+            let result =
+                <T as OncePointee>::set(&self.inner, unsafe { NonNull::new_unchecked(ptr) });
+
+            if result.is_err() {
                 let value = unsafe { Box::from_raw(ptr) };
                 return Err(value);
             }
+
             Ok(())
         }
 
@@ -386,27 +601,27 @@ mod once_box {
         where
             F: FnOnce() -> Result<Box<T>, E>,
         {
-            let mut ptr = self.inner.load(Ordering::Acquire);
+            let mut our_ptr: Option<NonNull<T>> = None;
 
-            if ptr.is_null() {
-                let val = f()?;
-                ptr = Box::into_raw(val);
-                let exchange = self.inner.compare_exchange(
-                    ptr::null_mut(),
-                    ptr,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                );
-                if let Err(old) = exchange {
-                    drop(unsafe { Box::from_raw(ptr) });
-                    ptr = old;
+            let ptr = <T as OncePointee>::get_or_try_init(&self.inner, || {
+                let ptr = Box::into_raw(f()?);
+                let ptr = unsafe { NonNull::new_unchecked(ptr) };
+                our_ptr = Some(ptr);
+                Ok(ptr)
+            })?;
+
+            // Deallocate our box if it's not the one that's stored.
+            if let Some(our_ptr) = our_ptr {
+                if ptr != our_ptr {
+                    drop(unsafe { Box::from_raw(our_ptr.as_ptr()) });
                 }
-            };
-            Ok(unsafe { &*ptr })
+            }
+
+            Ok(unsafe { ptr.as_ref() })
         }
     }
 
-    unsafe impl<T: Sync + Send> Sync for OnceBox<T> {}
+    unsafe impl<T: ?Sized + Sync + Send> Sync for OnceBox<T> {}
 
     /// ```compile_fail
     /// struct S(*mut ());

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use xshell::{cmd, Shell};
 
-const MSRV: &str = "1.60.0";
+const MSRV: &str = "1.64.0";
 
 fn main() -> xshell::Result<()> {
     let sh = Shell::new()?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use xshell::{cmd, Shell};
 
-const MSRV: &str = "1.64.0";
+const MSRV: &str = "1.61.0";
 
 fn main() -> xshell::Result<()> {
     let sh = Shell::new()?;


### PR DESCRIPTION
This is implemented through a new public-in-private `OncePointee` trait. If this was instead done with `impl OnceRef<[T]>`, the compiler fails to infer which methods we want to use.

Because of the usage of `core::ptr::slice_from_raw_parts` in `const`, this change increases the MSRV to `1.64.0`.

To make correctness easier to reason about, I did not use `Ordering::Relaxed`. However, it's likely that this code could be improved by it.