### PR TITLE
decouple alloc from race feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,10 @@ critical-section = { version = "1.1.1", features = ["std"] }
 [features]
 default = ["std"]
 
-# Enables `once_cell::sync` module.
-std = ["alloc"]
+# Enables `once_cell::sync` and `once_cell::race` modules.
+std = ["alloc", "race"]
 
-# Enables `once_cell::race::OnceBox` type.
-alloc = ["race"]
+alloc = []
 
 # Enables `once_cell::race` module.
 race = []


### PR DESCRIPTION
I would like to solve this build issue with `thumbv6m-none-eabi`: https://github.com/rustls/rustls/pull/2088#pullrequestreview-2274755137

With the `critical-section` feature, I don't need the `race` feature ... `once_cell::sync::OnceCell` is the perfect solution for all types of builds. But it still chokes on `race.rs`.

I would like to propose decoupling `alloc` from `race` to fix my build on `thumbv6m-none-eabi`.

Unfortunately I do think this would be a breaking change, guess we would need major version number bump. I would be happy to do this in this PR or let someone else do this.

I would be open to discussing some other alternatives, just hoping to find a way to resolve my build issue.

Thanks in advance!