### PR TITLE
Add portable-atomic feature and disable portable-atomic/critical-section by default

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -69,9 +69,6 @@ name = "portable-atomic"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
-dependencies = [
- "critical-section",
-]
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = ["xtask"]
 
 [dependencies]
 parking_lot_core = { version = "0.9.10", optional = true, default-features = false }
-portable-atomic = { version = "1.7", optional = true }
+portable-atomic = { version = "1.7", optional = true, default-features = false }
 critical-section = { version = "1.1.3", optional = true }
 
 [dev-dependencies]
@@ -38,17 +38,23 @@ std = ["alloc"]
 alloc = ["race"]
 
 # Enables `once_cell::race` module.
-race = []
+race = ["portable-atomic?/require-cas"]
 
 # Uses parking_lot to implement once_cell::sync::OnceCell.
 # This makes no speed difference, but makes each OnceCell<T>
 # up to 16 bytes smaller, depending on the size of the T.
 parking_lot = ["dep:parking_lot_core"]
 
-# Uses `critical-section` to implement `sync` and `race` modules. in
+# Uses `portable-atomic` to implement `race` module. in
+# `#![no_std]` mode. Please read `portable-atomic` docs carefully
+# before enabling this feature.
+portable-atomic = ["dep:portable-atomic"]
+
+# Uses `critical-section` to implement `sync` module. in
 # `#![no_std]` mode. Please read `critical-section` docs carefully
 # before enabling this feature.
-critical-section = ["dep:critical-section", "portable-atomic/critical-section"]
+# `portable-atomic` feature is enabled for backwards compatibility.
+critical-section = ["dep:critical-section", "portable-atomic"]
 
 # Enables semver-exempt APIs of this crate.
 # At the moment, this feature is unused.

--- a/src/race.rs
+++ b/src/race.rs
@@ -19,9 +19,9 @@
 //! `Acquire` and `Release` have very little performance overhead on most
 //! architectures versus `Relaxed`.
 
-#[cfg(not(feature = "critical-section"))]
+#[cfg(not(feature = "portable-atomic"))]
 use core::sync::atomic;
-#[cfg(feature = "critical-section")]
+#[cfg(feature = "portable-atomic")]
 use portable_atomic as atomic;
 
 use atomic::{AtomicPtr, AtomicUsize, Ordering};


### PR DESCRIPTION
Closes #264

This implements the first of the ways I mentioned in https://github.com/matklad/once_cell/issues/264#issuecomment-2354148809.

> * New Cargo feature to use `portable-atomic`'s atomic types instead of `core`'s

(The second way mentioned there was probably more user-friendly, but I did not choose it because it would have caused `portable-atomic` to appear in Cargo.lock as a platform-specific dependency. Like cfg-specific dependencies in https://github.com/crossbeam-rs/crossbeam/pull/487#issuecomment-783365041.)

No new test case was added, because the following case is sufficient to test the situation where the `race` module is enabled (due to default features) and `portable-atomic` is used instead of `core::sync::atomic` (due to `critical-section` feature enables `portable-atomic` feature).

https://github.com/matklad/once_cell/blob/72f7c2e5faed09e84aa1ffe26c25092c87954b98/xtask/src/main.rs#L40

This also closes #248 since this is a sound way to do that.

cc @kaspar030 @brodycj