### PR TITLE
Remove "portable-atomic?/require-cas" from race feature

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = ["xtask"]
 
 [dependencies]
 parking_lot_core = { version = "0.9.10", optional = true, default-features = false }
-portable-atomic = { version = "1.7", optional = true, default-features = false }
+portable-atomic = { version = "1.8", optional = true, default-features = false }
 critical-section = { version = "1.1.3", optional = true }
 
 [dev-dependencies]
@@ -38,7 +38,7 @@ std = ["alloc"]
 alloc = ["race"]
 
 # Enables `once_cell::race` module.
-race = ["portable-atomic?/require-cas"]
+race = []
 
 # Uses parking_lot to implement once_cell::sync::OnceCell.
 # This makes no speed difference, but makes each OnceCell<T>


### PR DESCRIPTION

This removes `"portable-atomic?/require-cas"` from `race` feature to work around Cargo bug (https://github.com/rust-lang/cargo/issues/10801).

Instead, this increases the minimal version of portable-atomic to 1.8 (which includes diagnostic improvements by https://github.com/taiki-e/portable-atomic/pull/181) so that it can keep good diagnostics with compilers at least Rust 1.78 (2024-05) or later.

More context: https://github.com/matklad/once_cell/pull/265#discussion_r1783125334
This is definitely a Cargo bug, but the fix does not seem to be easy: https://github.com/rust-lang/cargo/pull/11938
In my understanding, the only users who would be affected by this workaround are users of older compilers, so I think it is acceptable.