### PR TITLE
Add `OnceNonZeroUsize::get_unchecked`.

### DIFF
--- a/src/race.rs
+++ b/src/race.rs
@@ -50,6 +50,31 @@ impl OnceNonZeroUsize {
         NonZeroUsize::new(val)
     }
 
+    /// Get the reference to the underlying value, without checking if the cell
+    /// is initialized.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that the cell is in initialized state, and that
+    /// the contents are acquired by (synchronized to) this thread.
+    pub unsafe fn get_unchecked(&self) -> NonZeroUsize {
+        let p = self.inner.as_ptr();
+
+        // SAFETY: The caller is responsible for ensuring that the value
+        // was initialized and that the contents have been acquired by
+        // this thread. Assuming that, we can assume there will be no
+        // conflicting writes to the value since the value will never
+        // change once initialized. This relies on the statement in
+        // https://doc.rust-lang.org/1.83.0/core/sync/atomic/ that "(A
+        // `compare_exchange` or `compare_exchange_weak` that does not
+        // succeed is not considered a write."
+        let val = unsafe { p.read() };
+
+        // SAFETY: The caller is responsible for ensuring the value is
+        // initialized and thus not zero.
+        unsafe { NonZeroUsize::new_unchecked(val) }
+    }
+
     /// Sets the contents of this cell to `value`.
     ///
     /// Returns `Ok(())` if the cell was empty and `Err(())` if it was


### PR DESCRIPTION
Each call to `OnceNonZeroUsize::get()` results in an atomic load as the compiler will not cache and reuse the result of an atomic load.

Provide an analogous `get_unchecked()` that uses a non-atomic load. The compiler will be able to cache and reuse the result to avoid redundant loads.