### PR TITLE
Reduce MSRV to 1.65 by polyfilling `AtomicUsize::as_ptr()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
+## 1.21.1
+- Reduce MSRV to 1.65: [#277](https://github.com/matklad/once_cell/pull/277).
+
 ## 1.21.0
 
 - Outline initialization in `race`: [#273](https://github.com/matklad/once_cell/pull/273).
 - Add `OnceNonZereUsize::get_unchecked`: [#274](https://github.com/matklad/once_cell/pull/274).
 - Add `OnceBox::clone` and `OnceBox::with_value`: [#275](https://github.com/matklad/once_cell/pull/275).
+- Increase MSRV to 1.70
 
 ## 1.20.2
 

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -43,7 +43,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "once_cell"
-version = "1.21.0"
+version = "1.21.1"
 dependencies = [
  "critical-section",
  "parking_lot_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "once_cell"
-version = "1.21.0"
+version = "1.21.1"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.65"
 
 description = "Single assignment cells and lazy values."
 readme = "README.md"

--- a/src/race.rs
+++ b/src/race.rs
@@ -58,7 +58,23 @@ impl OnceNonZeroUsize {
     /// Caller must ensure that the cell is in initialized state, and that
     /// the contents are acquired by (synchronized to) this thread.
     pub unsafe fn get_unchecked(&self) -> NonZeroUsize {
-        let p = self.inner.as_ptr();
+        #[inline(always)]
+        fn as_const_ptr(r: &AtomicUsize) -> *const usize {
+            use core::mem::align_of;
+
+            let p: *const AtomicUsize = r;
+            // SAFETY: "This type has the same size and bit validity as
+            // the underlying integer type, usize. However, the alignment of
+            // this type is always equal to its size, even on targets where
+            // usize has a lesser alignment."
+            const _ALIGNMENT_COMPATIBLE: () =
+                assert!(align_of::<AtomicUsize>() % align_of::<usize>() == 0);
+            p.cast::<usize>()
+        }
+
+        // TODO(MSRV-1.70): Use `AtomicUsize::as_ptr().cast_const()`
+        // See https://github.com/rust-lang/rust/issues/138246.
+        let p = as_const_ptr(&self.inner);
 
         // SAFETY: The caller is responsible for ensuring that the value
         // was initialized and that the contents have been acquired by


### PR DESCRIPTION
Potentially the MSRV could be reduced further as `cargo +1.63.0 check` passes, but `cargo +1.63.0 test` fails:

```
$ cargo +1.63.0 test
error: package `regex-syntax v0.8.5` cannot be built because it requires
rustc 1.65 or newer, while the currently active rustc version is 1.63.0
```
