### PR TITLE
DRY `race::OnceRef::{get_or_try_init, set}`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.21.3
+
+- Outline more initialization in `race`: [#284](https://github.com/matklad/once_cell/pull/284),
+  [#285](https://github.com/matklad/once_cell/pull/285).
+
 ## 1.21.2
 - Relax success ordering from AcqRel to Release in `race`: [#278](https://github.com/matklad/once_cell/pull/278).
 

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -43,7 +43,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "once_cell"
-version = "1.21.2"
+version = "1.21.3"
 dependencies = [
  "critical-section",
  "parking_lot_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "once_cell"
-version = "1.21.2"
+version = "1.21.3"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Centralize all the pointer type casting and RMW into a new `compare_exchange` function as was done in other types in the module. Leave the dereferencing of the pointer in `init()` as `set()` doesn't ever use the old value.